### PR TITLE
Input/output classes

### DIFF
--- a/sdg/Indicator.py
+++ b/sdg/Indicator.py
@@ -1,38 +1,40 @@
+import sdg
+
 class Indicator:
     """Data model for SDG indicators."""
 
-    def __init__(self, inid, data=None, meta=None, headline=None, edges=None):
+    def __init__(self, inid, data=None, meta=None):
         """Constructor for the SDG indicator instances.
 
         Keyword arguments:
         inid -- The three-part dash-delimited ID (eg, 1-1-1).
         data -- Dataframe of all data.
         meta -- Dict of fielded metadata.
-        headline -- Dataframe of headline data.
-        edges -- Dataframe of data edges.
         """
         self.inid = inid
         self.data = data
         self.meta = meta
-        self.headline = headline
-        self.edges = edges
+        self.set_headline()
+        self.set_edges()
+
+    def has_data(self):
+        """Check to see if this indicator has data."""
+        return False if self.data is None else True
 
     def set_data(self, val):
         """Set the indicator data if a value is passed."""
         if val:
             self.data = val
+            self.set_headline()
+            self.set_edges()
 
     def set_meta(self, val):
         """Set the indicator metadata if a value is passed."""
         if val:
             self.meta = val
 
-    def set_headline(self, val):
-        """Set the indicator headline if a value is passed."""
-        if val:
-            self.headline = val
+    def set_headline(self):
+        self.headline = sdg.data.filter_headline(self.data) if self.has_data() else None
 
-    def set_edges(self, val):
-        """Set the indicator edges if a value is passed."""
-        if val:
-            self.edges = val
+    def set_edges(self):
+        self.edges = sdg.edges.edge_detection(self.inid, self.data) if self.has_data() else None

--- a/sdg/Indicator.py
+++ b/sdg/Indicator.py
@@ -1,0 +1,18 @@
+class Indicator:
+    """Data model for SDG indicators."""
+
+    def __init__(self, inid, data=None, meta=None, headline=None, edges=None):
+        """Constructor for the SDG indicator instances.
+
+        Keyword arguments:
+        inid -- The three-part dash-delimited ID (eg, 1-1-1).
+        data -- Dataframe of all data.
+        meta -- Dict of fielded metadata.
+        headline -- Dataframe of headline data.
+        edges -- Dataframe of data edges.
+        """
+        self.inid = inid
+        self.data = data
+        self.meta = meta
+        self.headline = headline
+        self.edges = edges

--- a/sdg/Indicator.py
+++ b/sdg/Indicator.py
@@ -16,3 +16,23 @@ class Indicator:
         self.meta = meta
         self.headline = headline
         self.edges = edges
+
+    def set_data(self, val):
+        """Set the indicator data if a value is passed."""
+        if val:
+            self.data = val
+
+    def set_meta(self, val):
+        """Set the indicator metadata if a value is passed."""
+        if val:
+            self.meta = val
+
+    def set_headline(self, val):
+        """Set the indicator headline if a value is passed."""
+        if val:
+            self.headline = val
+
+    def set_edges(self, val):
+        """Set the indicator edges if a value is passed."""
+        if val:
+            self.edges = val

--- a/sdg/__init__.py
+++ b/sdg/__init__.py
@@ -14,6 +14,7 @@ from . import check_metadata
 from . import schema
 from . import stats
 from . import inputs
+from . import Indicator
 from .check_metadata import check_all_meta
 from .check_csv import check_all_csv
 from .build import build_data

--- a/sdg/__init__.py
+++ b/sdg/__init__.py
@@ -13,6 +13,7 @@ from . import meta
 from . import check_metadata
 from . import schema
 from . import stats
+from . import inputs
 from .check_metadata import check_all_meta
 from .check_csv import check_all_csv
 from .build import build_data

--- a/sdg/__init__.py
+++ b/sdg/__init__.py
@@ -14,6 +14,7 @@ from . import check_metadata
 from . import schema
 from . import stats
 from . import inputs
+from . import outputs
 from . import Indicator
 from .check_metadata import check_all_meta
 from .check_csv import check_all_csv

--- a/sdg/build.py
+++ b/sdg/build.py
@@ -20,6 +20,7 @@ from sdg.json import write_json, df_to_list_dict
 
 # %% Read each csv and dump out to json and csv
 
+
 def build_data(src_dir='', site_dir='_site', git=True, git_data_dir=None,
                schema_file='_prose.yml', schema_type='prose', outputs=[]):
     """Read each input file and edge file and write out json.
@@ -37,7 +38,6 @@ def build_data(src_dir='', site_dir='_site', git=True, git_data_dir=None,
     Returns:
         Boolean status of file writes
     """
-
     status = True
 
     # If using the "outputs" parameter, execute those and then exit.

--- a/sdg/build.py
+++ b/sdg/build.py
@@ -20,9 +20,8 @@ from sdg.json import write_json, df_to_list_dict
 
 # %% Read each csv and dump out to json and csv
 
-
 def build_data(src_dir='', site_dir='_site', git=True, git_data_dir=None,
-               schema_file='_prose.yml', schema_type='prose'):
+               schema_file='_prose.yml', schema_type='prose', outputs=[]):
     """Read each input file and edge file and write out json.
 
     Args:
@@ -33,16 +32,24 @@ def build_data(src_dir='', site_dir='_site', git=True, git_data_dir=None,
         git_data_dir: str. Alternate folder with versioned data files.
         schema_file: Location of schema file relative to src_dir
         schema_type: Format of schema file
+        outputs: A list of output objects
 
     Returns:
         Boolean status of file writes
     """
+
     status = True
+
+    # If using the "outputs" parameter, execute those and then exit.
+    if len(outputs):
+        for output in outputs:
+            status = status & output.execute()
+        return status
 
     ids = sdg.path.get_ids(src_dir=src_dir)
     if len(ids) < 1:
         raise IOError('No ids found in src_dir: ' + src_dir)
-        
+
     print("Processing data for " + str(len(ids)) + " indicators...")
 
     all_meta = dict()
@@ -78,11 +85,11 @@ def build_data(src_dir='', site_dir='_site', git=True, git_data_dir=None,
         # combined
         comb = {'data': data_dict, 'edges': edges_dict}
         status = status & write_json(inid, comb, ftype='comb', gz=False, site_dir=site_dir)
-        
+
         # Metadata
         meta = sdg.meta.read_meta(inid, git=git, src_dir=src_dir, git_data_dir=git_data_dir)
         status = status & sdg.json.write_json(inid, meta, ftype='meta', site_dir=site_dir)
-        
+
         # Append to the build-time "all" output
         all_meta[inid] = meta
         all_headline[inid] = headline_dict
@@ -92,5 +99,5 @@ def build_data(src_dir='', site_dir='_site', git=True, git_data_dir=None,
 
     stats_reporting = sdg.stats.reporting_status(schema, all_meta)
     status = status & sdg.json.write_json('reporting', stats_reporting, ftype='stats', site_dir=site_dir)
-    
+
     return(status)

--- a/sdg/inputs/InputBase.py
+++ b/sdg/inputs/InputBase.py
@@ -4,6 +4,7 @@ class InputBase:
     def __init__(self):
         """Constructor for InputBase."""
         self.indicators = {}
+        self.fetch()
 
     def fetch(self):
         """Fetch all data/metadata from source, fetching a list of indicators."""

--- a/sdg/inputs/InputBase.py
+++ b/sdg/inputs/InputBase.py
@@ -4,8 +4,7 @@ class InputBase:
     def __init__(self):
         """Constructor for InputBase."""
         self.indicators = {}
-        self.fetch()
 
-    def fetch(self):
+    def execute(self):
         """Fetch all data/metadata from source, fetching a list of indicators."""
         raise NotImplementedError

--- a/sdg/inputs/InputBase.py
+++ b/sdg/inputs/InputBase.py
@@ -1,0 +1,6 @@
+class InputBase:
+    """Base class for sources of SDG data/metadata."""
+
+    def fetch(self):
+        """Fetch all data/metadata from source, returning a list of indicators."""
+        raise NotImplementedError

--- a/sdg/inputs/InputBase.py
+++ b/sdg/inputs/InputBase.py
@@ -1,6 +1,10 @@
 class InputBase:
     """Base class for sources of SDG data/metadata."""
 
+    def __init__(self):
+        """Constructor for InputBase."""
+        self.indicators = {}
+
     def fetch(self):
-        """Fetch all data/metadata from source, returning a list of indicators."""
+        """Fetch all data/metadata from source, fetching a list of indicators."""
         raise NotImplementedError

--- a/sdg/inputs/InputCsvData.py
+++ b/sdg/inputs/InputCsvData.py
@@ -1,4 +1,7 @@
+import pandas as pd
+import sdg
 from sdg.inputs import InputFiles
+from sdg.Indicator import Indicator
 
 class InputCsvData(InputFiles):
     """Sources of SDG data that are local CSV files."""
@@ -7,3 +10,12 @@ class InputCsvData(InputFiles):
         """Assume the file naming convention: 'indicator_1-1-1'."""
         inid = filename.replace('indicator_', '')
         return inid
+
+    def fetch(self):
+        """Get the data, edges, and headline from CSV, returning a list of indicators."""
+        indicator_map = self.get_indicator_map()
+        for inid in indicator_map:
+            data = pd.read_csv(indicator_map[inid])
+            edges = sdg.edges.edge_detection(inid, data)
+            headline = sdg.data.filter_headline(data)
+            self.indicators[inid] = Indicator(inid, data=data, edges=edges, headline=headline)

--- a/sdg/inputs/InputCsvData.py
+++ b/sdg/inputs/InputCsvData.py
@@ -11,7 +11,7 @@ class InputCsvData(InputFiles):
         inid = filename.replace('indicator_', '')
         return inid
 
-    def fetch(self):
+    def execute(self):
         """Get the data, edges, and headline from CSV, returning a list of indicators."""
         indicator_map = self.get_indicator_map()
         for inid in indicator_map:

--- a/sdg/inputs/InputCsvData.py
+++ b/sdg/inputs/InputCsvData.py
@@ -1,0 +1,9 @@
+from sdg.inputs import InputFiles
+
+class InputCsvData(InputFiles):
+    """Sources of SDG data that are local CSV files."""
+
+    def convert_filename_to_indicator_id(self, filename):
+        """Assume the file naming convention: 'indicator_1-1-1'."""
+        inid = filename.replace('indicator_', '')
+        return inid

--- a/sdg/inputs/InputCsvData.py
+++ b/sdg/inputs/InputCsvData.py
@@ -16,6 +16,4 @@ class InputCsvData(InputFiles):
         indicator_map = self.get_indicator_map()
         for inid in indicator_map:
             data = pd.read_csv(indicator_map[inid])
-            edges = sdg.edges.edge_detection(inid, data)
-            headline = sdg.data.filter_headline(data)
-            self.indicators[inid] = Indicator(inid, data=data, edges=edges, headline=headline)
+            self.indicators[inid] = Indicator(inid, data=data)

--- a/sdg/inputs/InputFiles.py
+++ b/sdg/inputs/InputFiles.py
@@ -30,11 +30,6 @@ class InputFiles(InputBase):
         paths = glob.glob(os.path.join(self.path_pattern))
         return paths
 
-    def get_indicator_ids(self):
-        """Return a list of all the indicator IDs contained in the local files."""
-        ids = [self.convert_path_to_indicator_id(path) for path in self.get_file_paths()]
-        return ids
-
     def get_indicator_map(self):
         """Return a dict of indicator ids to file paths."""
         indicator_map = {}

--- a/sdg/inputs/InputFiles.py
+++ b/sdg/inputs/InputFiles.py
@@ -34,3 +34,11 @@ class InputFiles(InputBase):
         """Return a list of all the indicator IDs contained in the local files."""
         ids = [self.convert_path_to_indicator_id(path) for path in self.get_file_paths()]
         return ids
+
+    def get_indicator_map(self):
+        """Return a dict of indicator ids to file paths."""
+        indicator_map = {}
+        for path in self.get_file_paths():
+            inid = self.convert_path_to_indicator_id(path)
+            indicator_map[inid] = path
+        return indicator_map

--- a/sdg/inputs/InputFiles.py
+++ b/sdg/inputs/InputFiles.py
@@ -1,0 +1,36 @@
+import glob
+import os
+from sdg.inputs import InputBase
+
+class InputFiles(InputBase):
+    """Sources of SDG data/metadata that are local files on disk."""
+
+    def __init__(self, path_pattern=''):
+        """Constructor for InputYamlMdMeta.
+
+        Keyword arguments:
+        path_pattern -- path (glob) pattern describing where the files are
+        """
+        self.path_pattern = path_pattern
+        InputBase.__init__(self)
+
+    def convert_filename_to_indicator_id(self, filename):
+        """Allow subclasses to tweak the way filenames are interpreted."""
+        return filename
+
+    def convert_path_to_indicator_id(self, path):
+        """Return the indicator ID from the path. Assumes it is the filename."""
+        filename = os.path.basename(path)
+        without_extension = os.path.splitext(filename)[0]
+        inid = self.convert_filename_to_indicator_id(without_extension)
+        return inid
+
+    def get_file_paths(self):
+        """Return a list of all the paths for the local data/metadata files."""
+        paths = glob.glob(os.path.join(self.path_pattern))
+        return paths
+
+    def get_indicator_ids(self):
+        """Return a list of all the indicator IDs contained in the local files."""
+        ids = [self.convert_path_to_indicator_id(path) for path in self.get_file_paths()]
+        return ids

--- a/sdg/inputs/InputYamlMdMeta.py
+++ b/sdg/inputs/InputYamlMdMeta.py
@@ -1,4 +1,7 @@
+import os
+import sdg
 from sdg.inputs import InputFiles
+from sdg.Indicator import Indicator
 
 class InputYamlMdMeta(InputFiles):
     """Sources of SDG metadata that are local .md files containing Yaml."""
@@ -12,3 +15,14 @@ class InputYamlMdMeta(InputFiles):
         """
         self.git = git
         InputFiles.__init__(self, path_pattern)
+
+    def fetch(self):
+        """Get the metadata from the YAML/Markdown, returning a list of indicators."""
+
+        indicator_map = self.get_indicator_map()
+        for inid in indicator_map:
+            # Need to get the folder of the folder of the indicator file.
+            src_dir = os.path.dirname(indicator_map[inid])
+            src_dir = os.path.dirname(src_dir)
+            meta = sdg.meta.read_meta(inid, git=self.git, src_dir=src_dir)
+            self.indicators[inid] = Indicator(inid, meta=meta)

--- a/sdg/inputs/InputYamlMdMeta.py
+++ b/sdg/inputs/InputYamlMdMeta.py
@@ -1,0 +1,14 @@
+from sdg.inputs import InputFiles
+
+class InputYamlMdMeta(InputFiles):
+    """Sources of SDG metadata that are local .md files containing Yaml."""
+
+    def __init__(self, path_pattern='', git=False):
+        """Constructor for InputYamlMdMeta.
+
+        Keyword arguments:
+        path_pattern -- path (glob) pattern describing where the files are
+        git -- whether to use git information for dates in the metadata
+        """
+        self.git = git
+        InputFiles.__init__(self, path_pattern)

--- a/sdg/inputs/InputYamlMdMeta.py
+++ b/sdg/inputs/InputYamlMdMeta.py
@@ -16,9 +16,8 @@ class InputYamlMdMeta(InputFiles):
         self.git = git
         InputFiles.__init__(self, path_pattern)
 
-    def fetch(self):
+    def execute(self):
         """Get the metadata from the YAML/Markdown, returning a list of indicators."""
-
         indicator_map = self.get_indicator_map()
         for inid in indicator_map:
             # Need to get the folder of the folder of the indicator file.

--- a/sdg/inputs/__init__.py
+++ b/sdg/inputs/__init__.py
@@ -1,0 +1,4 @@
+from .InputBase import InputBase
+from .InputFiles import InputFiles
+from .InputCsvData import InputCsvData
+from .InputYamlMdMeta import InputYamlMdMeta

--- a/sdg/outputs/OutputBase.py
+++ b/sdg/outputs/OutputBase.py
@@ -5,15 +5,26 @@ class OutputBase:
         """Constructor for OutputBase."""
         self.indicators = self.merge_inputs(inputs)
         self.output_folder = output_folder
-        self.write_output()
 
-    def write_output():
+    def execute():
         """Write the SDG output to disk."""
         raise NotImplementedError
 
     def merge_inputs(self, inputs):
         """Take the results of many inputs and merge into a single dict of indicators."""
         merged_indicators = {}
+        indicator_parts = ['data', 'metadata', 'headline', 'edges']
         for input in inputs:
-            merged_indicators.update(inputs[input].indicators)
+            # Fetch the input.
+            input.execute()
+            # Merge the results.
+            for inid in input.indicators:
+                if inid not in merged_indicators:
+                    merged_indicators[inid] = input.indicators[inid]
+                else:
+                    merged_indicators[inid].set_data(input.indicators[inid].data)
+                    merged_indicators[inid].set_meta(input.indicators[inid].meta)
+                    merged_indicators[inid].set_headline(input.indicators[inid].headline)
+                    merged_indicators[inid].set_edges(input.indicators[inid].edges)
+
         return merged_indicators

--- a/sdg/outputs/OutputBase.py
+++ b/sdg/outputs/OutputBase.py
@@ -1,0 +1,19 @@
+class OutputBase:
+    """Base class for destinations of SDG data/metadata."""
+
+    def __init__(self, inputs, output_folder=''):
+        """Constructor for OutputBase."""
+        self.indicators = self.merge_inputs(inputs)
+        self.output_folder = output_folder
+        self.write_output()
+
+    def write_output():
+        """Write the SDG output to disk."""
+        raise NotImplementedError
+
+    def merge_inputs(self, inputs):
+        """Take the results of many inputs and merge into a single dict of indicators."""
+        merged_indicators = {}
+        for input in inputs:
+            merged_indicators.update(inputs[input].indicators)
+        return merged_indicators

--- a/sdg/outputs/OutputBase.py
+++ b/sdg/outputs/OutputBase.py
@@ -13,7 +13,6 @@ class OutputBase:
     def merge_inputs(self, inputs):
         """Take the results of many inputs and merge into a single dict of indicators."""
         merged_indicators = {}
-        indicator_parts = ['data', 'metadata', 'headline', 'edges']
         for input in inputs:
             # Fetch the input.
             input.execute()
@@ -24,7 +23,5 @@ class OutputBase:
                 else:
                     merged_indicators[inid].set_data(input.indicators[inid].data)
                     merged_indicators[inid].set_meta(input.indicators[inid].meta)
-                    merged_indicators[inid].set_headline(input.indicators[inid].headline)
-                    merged_indicators[inid].set_edges(input.indicators[inid].edges)
 
         return merged_indicators

--- a/sdg/outputs/OutputOpenSdg.py
+++ b/sdg/outputs/OutputOpenSdg.py
@@ -12,9 +12,8 @@ class OutputOpenSdg(OutputBase):
         self.schema_path = schema_path
         OutputBase.__init__(self, inputs, output_folder)
 
-    def write_output(self):
+    def execute(self):
         """Write the JSON output expected by Open SDG."""
-
         status = True
         all_meta = dict()
         all_headline = dict()

--- a/sdg/outputs/OutputOpenSdg.py
+++ b/sdg/outputs/OutputOpenSdg.py
@@ -1,0 +1,58 @@
+import os
+import sdg
+from sdg.outputs import OutputBase
+from sdg.data import write_csv
+from sdg.json import write_json, df_to_list_dict
+
+class OutputOpenSdg(OutputBase):
+    """Output SDG data/metadata in the formats expected by Open SDG."""
+
+    def __init__(self, inputs, output_folder='', schema_path=''):
+        """Constructor for OutputBase."""
+        self.schema_path = schema_path
+        OutputBase.__init__(self, inputs, output_folder)
+
+    def write_output(self):
+        """Write the JSON output expected by Open SDG."""
+
+        status = True
+        all_meta = dict()
+        all_headline = dict()
+        site_dir = self.output_folder
+
+        # Write the schema.
+        schema_file = os.path.basename(self.schema_path)
+        schema_folder = os.path.dirname(self.schema_path)
+        schema = sdg.schema.get_schema(prose_file=schema_file, src_dir=schema_folder)
+        status = status & write_json('schema', schema, ftype='meta', gz=False, site_dir=site_dir)
+
+        for inid in self.indicators:
+            indicator = self.indicators[inid]
+            # Output all the csvs
+            status = status & write_csv(inid, indicator.data, ftype='data', site_dir=site_dir)
+            status = status & write_csv(inid, indicator.edges, ftype='edges', site_dir=site_dir)
+            status = status & write_csv(inid, indicator.headline, ftype='headline', site_dir=site_dir)
+            # And JSON
+            data_dict = df_to_list_dict(indicator.data, orient='list')
+            edges_dict = df_to_list_dict(indicator.edges, orient='list')
+            headline_dict = df_to_list_dict(indicator.headline, orient='records')
+
+            status = status & write_json(inid, data_dict, ftype='data', gz=False, site_dir=site_dir)
+            status = status & write_json(inid, edges_dict, ftype='edges', gz=False, site_dir=site_dir)
+            status = status & write_json(inid, headline_dict, ftype='headline', gz=False, site_dir=site_dir)
+
+            # combined
+            comb = {'data': data_dict, 'edges': edges_dict}
+            status = status & write_json(inid, comb, ftype='comb', gz=False, site_dir=site_dir)
+
+            # Metadata
+            status = status & sdg.json.write_json(inid, indicator.meta, ftype='meta', site_dir=site_dir)
+
+            # Append to the build-time "all" output
+            all_meta[inid] = indicator.meta
+            all_headline[inid] = headline_dict
+
+        status = status & sdg.json.write_json('all', all_meta, ftype='meta', site_dir=site_dir)
+        status = status & sdg.json.write_json('all', all_headline, ftype='headline', site_dir=site_dir)
+
+        return(status)

--- a/sdg/outputs/OutputOpenSdg.py
+++ b/sdg/outputs/OutputOpenSdg.py
@@ -7,9 +7,10 @@ from sdg.json import write_json, df_to_list_dict
 class OutputOpenSdg(OutputBase):
     """Output SDG data/metadata in the formats expected by Open SDG."""
 
-    def __init__(self, inputs, output_folder='', schema_path=''):
+    def __init__(self, inputs, output_folder='', schema_path='', schema_type='prose'):
         """Constructor for OutputBase."""
         self.schema_path = schema_path
+        self.schema_type = schema_type
         OutputBase.__init__(self, inputs, output_folder)
 
     def execute(self):
@@ -22,8 +23,11 @@ class OutputOpenSdg(OutputBase):
         # Write the schema.
         schema_file = os.path.basename(self.schema_path)
         schema_folder = os.path.dirname(self.schema_path)
-        schema = sdg.schema.get_schema(prose_file=schema_file, src_dir=schema_folder)
-        status = status & write_json('schema', schema, ftype='meta', gz=False, site_dir=site_dir)
+        schema = sdg.schema.Schema(schema_file=schema_file,
+                                   schema_type=self.schema_type,
+                                   src_dir=schema_folder)
+        status = status & schema.write_schema('schema', ftype='meta', gz=False, site_dir=site_dir)
+
 
         for inid in self.indicators:
             indicator = self.indicators[inid]
@@ -53,5 +57,8 @@ class OutputOpenSdg(OutputBase):
 
         status = status & sdg.json.write_json('all', all_meta, ftype='meta', site_dir=site_dir)
         status = status & sdg.json.write_json('all', all_headline, ftype='headline', site_dir=site_dir)
+
+        stats_reporting = sdg.stats.reporting_status(schema, all_meta)
+        status = status & sdg.json.write_json('reporting', stats_reporting, ftype='stats', site_dir=site_dir)
 
         return(status)

--- a/sdg/outputs/__init__.py
+++ b/sdg/outputs/__init__.py
@@ -1,0 +1,2 @@
+from .OutputBase import OutputBase
+from .OutputOpenSdg import OutputOpenSdg


### PR DESCRIPTION
Here's a beginning to a possible approach for #4, with a few types of classes:
* 2 "Input" classes: CSV data, and YAML/Markdown metadata
* 1 "Output" class: Open SDG format
* A basic class for indicators

This could use more testing, but a brief run locally seemed to work. Here is a snippet of how it would be used:
```
import os
import sdg

data_pattern = os.path.join('data', '*-*.csv')
data_input = sdg.inputs.InputCsvData(path_pattern=data_pattern)

meta_pattern = os.path.join('meta', '*-*.md')
meta_input = sdg.inputs.InputYamlMdMeta(path_pattern=meta_pattern)

inputs = [data_input, meta_input]

opensdg_output = sdg.outputs.OutputOpenSdg(inputs, output_folder='_site', schema_path='_prose.yml')
outputs = [opensdg_output]

sdg.build_data(outputs=outputs)
```

In theory this is not a breaking change, since it just adds a new optional param to build_data().

I say this is a "beginning" because right now the classes are still using the procedural functions from data.py, json.py, etc.. I assume that we'd probably want all that logic to live inside the appropriate class.

Also, I'm new to Python OOP standards to any feedback or advice is quite welcome.