### PR TITLE
Release 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Might become "release notes"
 
+### 0.3.1
+
+Minor release to ignore columns used in SDMX
+
 ## 0.3.0
 
 Adding the `stats` endpoint which is where reporting statistics will live. This

--- a/sdg/__init__.py
+++ b/sdg/__init__.py
@@ -1,6 +1,6 @@
 """Supporting scripts for sdg-indicators build"""
 
-__version__ = "0.2.0"
+__version__ = "0.3.1"
 __author__ = "Doug Ashton <douglas.j.ashton@gmail.com>"
 
 # Load key components

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='sdg',
-      version='0.3.0',
+      version='0.3.1',
       description='Build SDG data and metadata into output formats',
       url='https://github.com/ONSdigital/sdg-build',
       author='Doug Ashton',


### PR DESCRIPTION
Patch release to ignore SDMX columns. Only required for users wishing to use SDMX named columns in their data. Currently ignores:

* `Observation status`
* `Unit multiplier`