### PR TITLE
Update examples to raise exceptions when there is a validation failure.

### DIFF
--- a/docs/examples/ckan.py
+++ b/docs/examples/ckan.py
@@ -45,3 +45,5 @@ validation_successful = opensdg_output.validate()
 # If everything was valid, perform the build.
 if validation_successful:
     opensdg_output.execute()
+else
+    raise Exception('There were validation errors. See output above.')

--- a/docs/examples/open_sdg.py
+++ b/docs/examples/open_sdg.py
@@ -30,3 +30,5 @@ validation_successful = opensdg_output.validate()
 # If everything was valid, perform the build.
 if validation_successful:
     opensdg_output.execute()
+else
+    raise Exception('There were validation errors. See output above.')

--- a/docs/examples/sdmx_json.py
+++ b/docs/examples/sdmx_json.py
@@ -54,3 +54,5 @@ validation_successful = opensdg_output.validate()
 # If everything was valid, perform the build.
 if validation_successful:
     opensdg_output.execute()
+else
+    raise Exception('There were validation errors. See output above.')

--- a/docs/examples/sdmx_ml.py
+++ b/docs/examples/sdmx_ml.py
@@ -52,3 +52,5 @@ validation_successful = opensdg_output.validate()
 # If everything was valid, perform the build.
 if validation_successful:
     opensdg_output.execute()
+else
+    raise Exception('There were validation errors. See output above.')


### PR DESCRIPTION
In most cases, the validation will be used in continuous integration, where it would be necessary to raise an exception. So this updates the examples to show this practice.