### PR TITLE
Better validation errors

### DIFF
--- a/sdg/schemas/SchemaInputBase.py
+++ b/sdg/schemas/SchemaInputBase.py
@@ -62,6 +62,8 @@ class SchemaInputBase:
                 print('Validation errors for indicator ' + indicator.inid)
                 for error in self.validator.iter_errors(indicator.meta):
                     print(error.message)
+                    print(error.context)
+                    print(error.cause)
 
         return status
 

--- a/sdg/schemas/SchemaInputBase.py
+++ b/sdg/schemas/SchemaInputBase.py
@@ -62,8 +62,10 @@ class SchemaInputBase:
                 print('Validation errors for indicator ' + indicator.inid)
                 for error in self.validator.iter_errors(indicator.meta):
                     print(error.message)
-                    print(error.context)
-                    print(error.cause)
+                    print(error.schema)
+                    print(error.schema_path)
+                    print(error.validator)
+                    print(error.validator_value)
 
         return status
 

--- a/sdg/schemas/SchemaInputBase.py
+++ b/sdg/schemas/SchemaInputBase.py
@@ -61,11 +61,13 @@ class SchemaInputBase:
                 status = False
                 print('Validation errors for indicator ' + indicator.inid)
                 for error in self.validator.iter_errors(indicator.meta):
-                    print(error.message)
-                    print(error.schema)
-                    print(error.schema_path)
-                    print(error.validator)
-                    print(error.validator_value)
+                    ignore = ['properties', 'type']
+                    things = []
+                    for thing in error.schema_path:
+                        if thing not in ignore:
+                            things.append(thing)
+                    things = '/'.join(things)
+                    print('- ' + error.schema['title'] + ' (' + things + '): ' + error.message)
 
         return status
 


### PR DESCRIPTION
This improves the validation errors produced by the jsonschema validation. An example of the new output is:
```
Validation errors for indicator 4-5-1-2
- Unit of measurement (computation_units): None is not of type 'string', 'integer'
- Compilation (source_compilation_1): None is not of type 'string', 'integer'
- Implementation (source_implementation_1): None is not of type 'string', 'integer'
- Data (source_data_1): None is not of type 'string', 'integer'
Validation errors for indicator 6-2-1
- Data (source_data_1): None is not of type 'string', 'integer'
Validation errors for indicator 12-1-1
- Unit of measurement (computation_units): None is not of type 'string', 'integer'
- Data (source_data_1): None is not of type 'string', 'integer'
```
This is an improvement over the current situation, which would be:
```
Validation errors for indicator 4-5-1-2
None is not of type 'string', 'integer'
None is not of type 'string', 'integer'
None is not of type 'string', 'integer'
None is not of type 'string', 'integer'
Validation errors for indicator 6-2-1
None is not of type 'string', 'integer'
Validation errors for indicator 12-1-1
None is not of type 'string', 'integer'
None is not of type 'string', 'integer'
```