### PR TITLE
Allow reporting stats to include extra fields

### DIFF
--- a/docs/examples/open_sdg_config.yml
+++ b/docs/examples/open_sdg_config.yml
@@ -35,3 +35,9 @@ site_dir: _site
 # This identifies a file containing the schema (possible fields) for metadata.
 # Currently this needs to be a prose.io config, and defaults to '_prose.yml'.
 schema_file: _prose.yml
+
+# Reporting status extra fields
+# -----------------------------
+# This allows the build to generate stats for reporting status by additional
+# fields, beyond the default "status by goal" report.
+reporting_status_extra_fields: []

--- a/sdg/open_sdg.py
+++ b/sdg/open_sdg.py
@@ -163,10 +163,15 @@ def open_sdg_prep(options):
     if os.path.isdir(translation_dir):
         all_translations.append(sdg.translations.TranslationInputYaml(source=translation_dir))
 
+    # Indicate any extra fields for the reporting stats, if needed.
+    reporting_status_extra_fields = []
+    if 'reporting_status_extra_fields' in options:
+        reporting_status_extra_fields = options['reporting_status_extra_fields']
+
     # Create an "output" from these inputs/schema/translations, for Open SDG output.
     return sdg.outputs.OutputOpenSdg(
         inputs=inputs,
         schema=schema,
         output_folder=options['site_dir'],
         translations=all_translations,
-        reporting_status_extra_fields=options['reporting_status_extra_fields'])
+        reporting_status_extra_fields=reporting_status_extra_fields)

--- a/sdg/open_sdg.py
+++ b/sdg/open_sdg.py
@@ -36,7 +36,8 @@ def open_sdg_config(config_file, defaults):
 
 
 def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
-                   languages=None, translations=None, config='open_sdg_config.yml'):
+                   languages=None, translations=None,
+                   reporting_status_extra_fields=None, config='open_sdg_config.yml'):
     """Read each input file and edge file and write out json.
 
     Args:
@@ -46,6 +47,8 @@ def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
         schema_file: str. Location of schema file relative to src_dir
         languages: list. A list of language codes, for translated builds
         translations: list. A list of git repositories to pull translations from
+        reporting_status_extra_fields: list. A list of extra fields to generate
+          reporting stats for.
         config: str. Path to a YAML config file that overrides other parameters
 
     Returns:
@@ -60,7 +63,8 @@ def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
         'site_dir': site_dir,
         'schema_file': schema_file,
         'languages': languages,
-        'translations': translations
+        'translations': translations,
+        'reporting_status_extra_fields': reporting_status_extra_fields
     }
     # Allow for a config file to update these.
     options = open_sdg_config(config, defaults)
@@ -164,4 +168,5 @@ def open_sdg_prep(options):
         inputs=inputs,
         schema=schema,
         output_folder=options['site_dir'],
-        translations=all_translations)
+        translations=all_translations,
+        reporting_status_extra_fields=options['reporting_status_extra_fields'])

--- a/sdg/outputs/OutputBase.py
+++ b/sdg/outputs/OutputBase.py
@@ -7,7 +7,17 @@ class OutputBase:
 
 
     def __init__(self, inputs, schema, output_folder='', translations=[]):
-        """Constructor for OutputBase."""
+        """Constructor for OutputBase.
+
+        inputs: list
+            A list of InputBase (or descendent) classes.
+        schema: SchemaInputBase
+            An instance of SchemaInputBase (or descendant).
+        output_folder: string
+            The path to where the output files should be created.
+        translations: list
+            A list of TranslationInputBase (or descendant) classes.
+        """
         self.indicators = self.merge_inputs(inputs)
         self.schema = schema
         self.output_folder = output_folder

--- a/sdg/outputs/OutputOpenSdg.py
+++ b/sdg/outputs/OutputOpenSdg.py
@@ -8,6 +8,24 @@ class OutputOpenSdg(OutputBase):
     """Output SDG data/metadata in the formats expected by Open SDG."""
 
 
+    def __init__(self, inputs, schema, output_folder='', translations=[],
+        reporting_status_grouping_fields=None):
+        """Constructor for OutputOpenSdg.
+
+        Parameters
+        ----------
+
+        Inherits all the parameters from OutputBase, plus the following:
+
+        reporting_status_grouping_fields : string
+            To be passed as "grouping_fields" to sdg.stats.reporting_status.
+
+
+        """
+        OutputBase.__init__(self, inputs, schema, output_folder, translations)
+        self.reporting_status_grouping_fields = reporting_status_grouping_fields
+
+
     def build(self, language=None):
         """Write the JSON output expected by Open SDG. Overrides parent."""
         status = True
@@ -58,7 +76,7 @@ class OutputOpenSdg(OutputBase):
         status = status & sdg.json.write_json('all', all_meta, ftype='meta', site_dir=site_dir)
         status = status & sdg.json.write_json('all', all_headline, ftype='headline', site_dir=site_dir)
 
-        stats_reporting = sdg.stats.reporting_status(self.schema, all_meta)
+        stats_reporting = sdg.stats.reporting_status(self.schema, all_meta, self.reporting_status_grouping_fields)
         status = status & sdg.json.write_json('reporting', stats_reporting, ftype='stats', site_dir=site_dir)
 
         indicator_export_service = sdg.IndicatorExportService(site_dir)

--- a/sdg/outputs/OutputOpenSdg.py
+++ b/sdg/outputs/OutputOpenSdg.py
@@ -9,7 +9,7 @@ class OutputOpenSdg(OutputBase):
 
 
     def __init__(self, inputs, schema, output_folder='', translations=[],
-        reporting_status_grouping_fields=None):
+        reporting_status_extra_fields=None):
         """Constructor for OutputOpenSdg.
 
         Parameters
@@ -17,13 +17,13 @@ class OutputOpenSdg(OutputBase):
 
         Inherits all the parameters from OutputBase, plus the following:
 
-        reporting_status_grouping_fields : string
-            To be passed as "grouping_fields" to sdg.stats.reporting_status.
+        reporting_status_extra_fields : string
+            To be passed as "extra_fields" to sdg.stats.reporting_status.
 
 
         """
         OutputBase.__init__(self, inputs, schema, output_folder, translations)
-        self.reporting_status_grouping_fields = reporting_status_grouping_fields
+        self.reporting_status_grouping_fields = reporting_status_extra_fields
 
 
     def build(self, language=None):

--- a/sdg/stats.py
+++ b/sdg/stats.py
@@ -79,7 +79,7 @@ def reporting_status(schema, all_meta, extra_fields=None):
     output = {
         'statuses': status_report,
         'overall': total_report,
-        'fields': {},
+        'extra_fields': {},
     }
 
     # Add on a report for each of our grouping fields.
@@ -93,9 +93,10 @@ def reporting_status(schema, all_meta, extra_fields=None):
                                 for status in status_values],
                     'totals': {'total': g['total']}
                 })
-        output['fields'][field] = grouped_report
+        output['extra_fields'][field] = grouped_report
 
-    # Backwards compatibility.
-    output['goals'] = output['fields']['sdg_goal']
+    # Treat goals specially, by putting it outside of "extra_fields".
+    output['goals'] = output['extra_fields']['sdg_goal']
+    del output['extra_fields']['sdg_goal']
 
     return output

--- a/sdg/stats.py
+++ b/sdg/stats.py
@@ -9,20 +9,21 @@ Aggregate information for reporting statistics
 import pandas as pd
 
 
-def reporting_status(schema, all_meta, grouping_fields=None):
+def reporting_status(schema, all_meta, extra_fields=None):
     """
     Args:
         schema: An object of class "Schema" containing the metadata schema
         all_meta: A dictionary containing all metadata items
-        grouping_fields: List of fields to group stats by (default: ['sdg_goal'])
+        extra_fields: List of fields to group stats by, in addition to goal
 
     Returns:
         Dictionary of reporting statuses at group_by_field and total level
     """
 
-    # For backwards compatibility, use a default grouping field of 'sdg_goal'.
-    if grouping_fields is None:
-        grouping_fields = ['sdg_goal']
+    # Make sure 'sdg_goal' is in the list of fields.
+    grouping_fields = extra_fields if extra_fields is not None else []
+    if 'sdg_goal' not in grouping_fields:
+        grouping_fields.append('sdg_goal')
 
     # Generate a report of the possible statuses, both value and translations.
     status_values = schema.get_values('reporting_status')
@@ -78,7 +79,7 @@ def reporting_status(schema, all_meta, grouping_fields=None):
     output = {
         'statuses': status_report,
         'overall': total_report,
-        'grouping_fields': grouping_fields,
+        'fields': {},
     }
 
     # Add on a report for each of our grouping fields.
@@ -92,6 +93,9 @@ def reporting_status(schema, all_meta, grouping_fields=None):
                                 for status in status_values],
                     'totals': {'total': g['total']}
                 })
-        output[field] = grouped_report
+        output['fields'][field] = grouped_report
+
+    # Backwards compatibility.
+    output['goals'] = output['fields']['sdg_goal']
 
     return output

--- a/sdg/stats.py
+++ b/sdg/stats.py
@@ -17,7 +17,8 @@ def reporting_status(schema, all_meta, extra_fields=None):
         extra_fields: List of fields to group stats by, in addition to goal
 
     Returns:
-        Dictionary of reporting statuses at group_by_field and total level
+        Dictionary of reporting statuses at goal (plus any extra fields) and
+        total level
     """
 
     # Make sure 'sdg_goal' is in the list of fields.

--- a/sdg/stats.py
+++ b/sdg/stats.py
@@ -86,9 +86,12 @@ def reporting_status(schema, all_meta, extra_fields=None):
     for field in grouped_dfs:
         grouped_report = list()
         for index, g in grouped_dfs[field].reset_index().iterrows():
+            # Because the goals report is treated differently, standardize on
+            # the key of "goal" instead of "sdg_goals".
+            fixed_field_name = field.replace('sdg_goal', 'goal')
             grouped_report.append(
                 {
-                    field: g[field],
+                    fixed_field_name: g[field],
                     'statuses': [one_status_report(g, status)
                                 for status in status_values],
                     'totals': {'total': g['total']}


### PR DESCRIPTION
This is needed for [this issue](https://github.com/open-sdg/open-sdg/issues/209). It is not a breaking change - it only adds an "extra_fields" property in the reporting stats.

## How it works

An Open SDG site's "data repository" needs to be configured to add "extra_fields" to the reporting stats output. This can be done in the OutputOpenSdg class with a `reporting_status_extra_fields` parameter. For example, instead of this:
```
opensdg_output = sdg.outputs.OutputOpenSdg(
    inputs=inputs,
    schema=schema,
    output_folder='_site',
    translations=translations)
```
You would do this:
```
opensdg_output = sdg.outputs.OutputOpenSdg(
    inputs=inputs,
    schema=schema,
    output_folder='_site',
    translations=translations,
    reporting_status_extra_fields=['an_extra_field', 'another_extra_field'])
```