### PR TITLE
Allow SDMX to import translation keys instead of text

### DIFF
--- a/docs/examples/sdmx_json.py
+++ b/docs/examples/sdmx_json.py
@@ -35,6 +35,7 @@ data_input = sdg.inputs.InputSdmxJson(
     source=source,
     dimension_map=dimension_map,
     dsd=dsd,
+    import_translation_keys=True,
     indicator_id_map=indicator_id_map,
     indicator_id_xpath=indicator_id_xpath,
     indicator_name_xpath=indicator_name_xpath

--- a/docs/examples/sdmx_json.py
+++ b/docs/examples/sdmx_json.py
@@ -50,8 +50,8 @@ translations = [
     # Use two Git repos containing translations.
     sdg.translations.TranslationInputSdgTranslations(source='https://github.com/open-sdg/translations-un-sdg.git', tag='1.0.0-rc1'),
     sdg.translations.TranslationInputSdgTranslations(source='https://github.com/open-sdg/translations-open-sdg.git', tag='1.0.0-rc2'),
-    # Also look for translations in a local 'translations' folder.
-    sdg.translations.TranslationInputYaml(source='translations'),
+    # Also pull in translations from the SDMX DSD.
+    sdg.translations.TranslationInputSdmx(source=dsd),
 ]
 
 # Create an "output" from these inputs and schema, for JSON for Open SDG.

--- a/docs/examples/sdmx_ml.py
+++ b/docs/examples/sdmx_ml.py
@@ -34,6 +34,7 @@ data_input = sdg.inputs.InputSdmxMl_Structure(
     dimension_map=dimension_map,
     dsd=dsd,
     drop_dimensions=drop_dimensions,
+    import_translation_keys=True,
     indicator_id_xpath=indicator_id_xpath,
     indicator_name_xpath=indicator_name_xpath
 )

--- a/docs/examples/sdmx_ml.py
+++ b/docs/examples/sdmx_ml.py
@@ -48,8 +48,8 @@ translations = [
     # Use two Git repos containing translations.
     sdg.translations.TranslationInputSdgTranslations(source='https://github.com/open-sdg/translations-un-sdg.git', tag='1.0.0-rc1'),
     sdg.translations.TranslationInputSdgTranslations(source='https://github.com/open-sdg/translations-open-sdg.git', tag='1.0.0-rc2'),
-    # Also look for translations in a local 'translations' folder.
-    sdg.translations.TranslationInputYaml(source='translations'),
+    # Also pull in translations from the SDMX DSD.
+    sdg.translations.TranslationInputSdmx(source=dsd),
 ]
 
 # Create an "output" from these inputs and schema, for JSON for Open SDG.

--- a/sdg/inputs/InputSdmx.py
+++ b/sdg/inputs/InputSdmx.py
@@ -14,7 +14,7 @@ class InputSdmx(InputBase):
                  dimension_map={},
                  indicator_id_map={},
                  import_names=True,
-                 import_translation_keys=True,
+                 import_translation_keys=False,
                  dsd='https://unstats.un.org/sdgs/files/SDG_DSD.xml',
                  indicator_id_xpath=".//Annotation[AnnotationTitle='Indicator']/AnnotationText",
                  indicator_name_xpath=".//Annotation[AnnotationTitle='IndicatorTitle']/AnnotationText"):
@@ -49,7 +49,11 @@ class InputSdmx(InputBase):
             Whether to import names. Set to False to rely on global names
         import_translation_keys : boolean
             Whether to import translation keys instead of text values. Set to
-            False to import text values (taken from the first language in the DSD).
+            True to import translation keys, which will be in the format of:
+            * code.[id]
+            * concept.[id]
+            If left False, text values are imported instead, taken from the
+            first language in the DSD.
         dsd : string
             Remote URL of the SDMX DSD (data structure definition) or path to
             local file.

--- a/sdg/inputs/InputSdmx.py
+++ b/sdg/inputs/InputSdmx.py
@@ -14,6 +14,7 @@ class InputSdmx(InputBase):
                  dimension_map={},
                  indicator_id_map={},
                  import_names=True,
+                 import_translation_keys=True,
                  dsd='https://unstats.un.org/sdgs/files/SDG_DSD.xml',
                  indicator_id_xpath=".//Annotation[AnnotationTitle='Indicator']/AnnotationText",
                  indicator_name_xpath=".//Annotation[AnnotationTitle='IndicatorTitle']/AnnotationText"):
@@ -46,6 +47,9 @@ class InputSdmx(InputBase):
             }
         import_names : boolean
             Whether to import names. Set to False to rely on global names
+        import_translation_keys : boolean
+            Whether to import translation keys instead of text values. Set to
+            False to import text values (taken from the first language in the DSD).
         dsd : string
             Remote URL of the SDMX DSD (data structure definition) or path to
             local file.
@@ -61,6 +65,7 @@ class InputSdmx(InputBase):
         self.dimension_map = dimension_map
         self.indicator_id_map = indicator_id_map
         self.import_names = import_names
+        self.import_translation_keys = import_translation_keys
         self.indicator_id_xpath = indicator_id_xpath
         self.indicator_name_xpath = indicator_name_xpath
         self.series_dimensions = {}
@@ -165,6 +170,8 @@ class InputSdmx(InputBase):
         string
             The human-readable SDMX Concept name
         """
+        if self.import_translation_keys:
+            return 'concept.' + concept_id
         concept = self.get_concept(concept_id)
         return concept.find(".//Name").text
 
@@ -304,6 +311,9 @@ class InputSdmx(InputBase):
         # Aggregate values are always "_T", these can be empty strings.
         if dimension_value_id == '_T':
             return None
+        # Just return the id if necessary.
+        if self.import_translation_keys:
+            return 'code.' + dimension_value_id
         # Otherwise default to whatever is in the SDMX.
         codelist_id = self.dimension_id_to_codelist_id(dimension_id)
         if codelist_id:


### PR DESCRIPTION
Fixes #90 

This adds an `import_translation_keys` parameter to the SDMX inputs, which instructs them to pull in "translation keys" rather than fully-translated text. These follow the format of "`code.`" plus the id of the code, and "`concept.`" plus the id of the concept. This convention matches what is generated by this library's TranslationInputSdmx class, allowing the two to be used in combination.

For example, rather than pulling in "Per 1,000 live births", it would pull in "code.PER_1000_LIVE_BIRTHS" instead. At the same time, the TranslationInputSdmx class would have pulled in a translation structure like this:
```
{
    "en": {
        "code": {
            "PER_1000_LIVE_BIRTHS": "Per 1,000 live births"
        }
    }
}
```