### PR TITLE
Never use [] or {} as parameter defaults

### DIFF
--- a/sdg/Indicator.py
+++ b/sdg/Indicator.py
@@ -155,7 +155,7 @@ class Indicator:
         return self.inid.replace('-', '.')
 
 
-    def require_meta(self, minimum_metadata={}):
+    def require_meta(self, minimum_metadata=None):
         """Ensure the metadata for this indicator has minimum necessary values.
 
         Parameters
@@ -163,6 +163,9 @@ class Indicator:
         minimum_metadata : Dict
             Key/value pairs of minimum metadata for this indicator.
         """
+        if minimum_metadata is None:
+            minimum_metadata = {}
+
         if self.meta is None:
             self.meta = minimum_metadata
         else:

--- a/sdg/inputs/InputSdmx.py
+++ b/sdg/inputs/InputSdmx.py
@@ -9,10 +9,10 @@ class InputSdmx(InputBase):
 
     def __init__(self,
                  source='',
-                 drop_dimensions=[],
+                 drop_dimensions=None,
                  drop_singleton_dimensions=True,
-                 dimension_map={},
-                 indicator_id_map={},
+                 dimension_map=None,
+                 indicator_id_map=None,
                  import_names=True,
                  import_translation_keys=False,
                  dsd='https://unstats.un.org/sdgs/files/SDG_DSD.xml',
@@ -62,6 +62,13 @@ class InputSdmx(InputBase):
         indicator_name_xpath : string
             An xpath query to find the indicator name within each Series code
         """
+        if drop_dimensions is None:
+            drop_dimensions = []
+        if dimension_map is None:
+            dimension_map = {}
+        if indicator_id_map is None:
+            indicator_id_map = {}
+
         self.source = source
         self.dsd = self.parse_xml(dsd)
         self.drop_dimensions = drop_dimensions

--- a/sdg/outputs/OutputBase.py
+++ b/sdg/outputs/OutputBase.py
@@ -6,7 +6,7 @@ class OutputBase:
     """Base class for destinations of SDG data/metadata."""
 
 
-    def __init__(self, inputs, schema, output_folder='', translations=[]):
+    def __init__(self, inputs, schema, output_folder='', translations=None):
         """Constructor for OutputBase.
 
         inputs: list
@@ -18,6 +18,9 @@ class OutputBase:
         translations: list
             A list of TranslationInputBase (or descendant) classes.
         """
+        if translations is None:
+            translations = []
+
         self.indicators = self.merge_inputs(inputs)
         self.schema = schema
         self.output_folder = output_folder

--- a/sdg/outputs/OutputOpenSdg.py
+++ b/sdg/outputs/OutputOpenSdg.py
@@ -8,7 +8,7 @@ class OutputOpenSdg(OutputBase):
     """Output SDG data/metadata in the formats expected by Open SDG."""
 
 
-    def __init__(self, inputs, schema, output_folder='', translations=[],
+    def __init__(self, inputs, schema, output_folder='', translations=None,
         reporting_status_extra_fields=None):
         """Constructor for OutputOpenSdg.
 
@@ -22,6 +22,9 @@ class OutputOpenSdg(OutputBase):
 
 
         """
+        if translations is None:
+            translations = []
+
         OutputBase.__init__(self, inputs, schema, output_folder, translations)
         self.reporting_status_grouping_fields = reporting_status_extra_fields
 


### PR DESCRIPTION
I just realized how disastrous it is to use lists or dicts as default parameters. (It basically turns those into class-wide static variables.) This should fix the cases we have here.