### PR TITLE
Set indicator_name instead of indicator_name_national

### DIFF
--- a/sdg/outputs/OutputOpenSdg.py
+++ b/sdg/outputs/OutputOpenSdg.py
@@ -123,7 +123,7 @@ class OutputOpenSdg(OutputBase):
 
         # Add names only if the indicator has one.
         if indicator.has_name():
-            minimum['indicator_name_national'] = indicator.get_name()
+            minimum['indicator_name'] = indicator.get_name()
             minimum['graph_title'] = indicator.get_name()
 
         return minimum


### PR DESCRIPTION
Open SDG now relies on `indicator_name` instead of `indicator_name_national`, so this updates the minimum metadata for the Open SDG output accordingly.