### PR TITLE
Translate nested metadata

### DIFF
--- a/sdg/Indicator.py
+++ b/sdg/Indicator.py
@@ -225,7 +225,7 @@ class Indicator:
             if isinstance(text, dict):
                 return {key: translate_meta(value) for (key, value) in text.items()}
             # Otherwise treat as a string.
-            return translation_helper.translate(text, language)
+            return translation_helper.translate(text, language, default_group='data')
         def translate_data(text):
             return translation_helper.translate(text, language, default_group='data')
 

--- a/sdg/Indicator.py
+++ b/sdg/Indicator.py
@@ -218,6 +218,13 @@ class Indicator:
 
         # Translation callbacks for below.
         def translate_meta(text):
+            # Recursively handle lists.
+            if isinstance(text, list):
+                return [translate_meta(value) for value in text]
+            # Recursively handle dicts.
+            if isinstance(text, dict):
+                return {key: translate_meta(value) for (key, value) in text.items()}
+            # Otherwise treat as a string.
             return translation_helper.translate(text, language)
         def translate_data(text):
             return translation_helper.translate(text, language, default_group='data')


### PR DESCRIPTION
Right now, if an indicator's metadata contains lists or dicts, those values do not get translated in any translated builds. This change adds support for translating dicts and lists in metadata, using some recursion.