### PR TITLE
SDMX translation codelist in key

### DIFF
--- a/sdg/inputs/InputSdmx.py
+++ b/sdg/inputs/InputSdmx.py
@@ -322,12 +322,12 @@ class InputSdmx(InputBase):
         # Aggregate values are always "_T", these can be empty strings.
         if dimension_value_id == '_T':
             return None
-        # Just return the ids (as a "translation key") if necessary.
-        if self.import_translation_keys:
-            return dimension_id + '.' + dimension_value_id
-        # Otherwise default to whatever is in the SDMX.
         codelist_id = self.dimension_id_to_codelist_id(dimension_id)
         if codelist_id:
+            # Return the ids (as a "translation key") if necessary.
+            if self.import_translation_keys:
+                return codelist_id + '.' + dimension_value_id
+            # Otherwise default to whatever is in the SDMX.
             code = self.get_code(codelist_id, dimension_value_id)
             if code is not None:
                 return code.find(".//Name").text

--- a/sdg/inputs/InputSdmx.py
+++ b/sdg/inputs/InputSdmx.py
@@ -322,9 +322,9 @@ class InputSdmx(InputBase):
         # Aggregate values are always "_T", these can be empty strings.
         if dimension_value_id == '_T':
             return None
-        # Just return the id if necessary.
+        # Just return the ids (as a "translation key") if necessary.
         if self.import_translation_keys:
-            return 'code.' + dimension_value_id
+            return dimension_id + '.' + dimension_value_id
         # Otherwise default to whatever is in the SDMX.
         codelist_id = self.dimension_id_to_codelist_id(dimension_id)
         if codelist_id:

--- a/sdg/translations/TranslationInputSdmx.py
+++ b/sdg/translations/TranslationInputSdmx.py
@@ -46,7 +46,6 @@ class TranslationInputSdmx(TranslationInputBase):
         groups = {
             'category': './/Category',
             'codelist': './/Codelist',
-            'code': './/Code',
             'concept': './/Concept',
         }
         for group in groups:
@@ -54,6 +53,22 @@ class TranslationInputSdmx(TranslationInputBase):
             for tag in tags:
                 key = tag.attrib['id']
                 translations = tag.findall('.//Name')
+                for translation in translations:
+                    if 'lang' not in translation.attrib:
+                        continue
+                    language = translation.attrib['lang']
+                    value = translation.text
+                    self.add_translation(language, group, key, value)
+
+        # We treat Code elements differently. Because there can be duplicates,
+        # we use the Codelist ids are the "group".
+        codelists = dsd.findall('.//Codelist')
+        for codelist in codelists:
+            group = codelist.attrib['id']
+            codes = codelist.findall('Code')
+            for code in codes:
+                translations = code.findall('Name')
+                key = code.attrib['id']
                 for translation in translations:
                     if 'lang' not in translation.attrib:
                         continue


### PR DESCRIPTION
This makes the imported SDMX "Code" translations "namespaced" by their "Codelist" id.