### PR TITLE
Print warning instead of exception when series has duplicate value

### DIFF
--- a/sdg/Indicator.py
+++ b/sdg/Indicator.py
@@ -334,7 +334,7 @@ class Indicator:
             serialized = json.dumps(disaggregations, sort_keys=True)
             # Initialized any new series.
             if serialized not in all_series:
-                all_series[serialized] = sdg.Series(disaggregations)
+                all_series[serialized] = sdg.Series(disaggregations, self.get_indicator_id())
             # Finally add the year and value.
             all_series[serialized].add_value(row['Year'], row['Value'])
 

--- a/sdg/Series.py
+++ b/sdg/Series.py
@@ -67,9 +67,10 @@ class Series:
             The numerical value to add.
         """
         if year in self.values:
-            raise KeyError('There is already a value for this year.')
-
-        self.values[year] = value
+            warning = '\nWARNING: Duplicate values for year {}: {} and {} in series: {}'
+            print(warning.format(year, value, self.values[year], self.get_disaggregations()))
+        else:
+            self.values[year] = value
 
     def has_disaggregation(self, disaggregation):
         """Check to see if the series has a specific disaggregation.

--- a/sdg/Series.py
+++ b/sdg/Series.py
@@ -24,16 +24,19 @@ class Series:
         }
     """
 
-    def __init__(self, disaggregations):
+    def __init__(self, disaggregations, indicator_id='Indicator'):
         """Constructor for the SDG series instances.
 
         Parameters
         ----------
         disaggregations : dict
             A dict describing the disaggregations contained in the series.
+        indicator_id : string
+            Optional indicator ID this series is a part of (eg, 1.1.1).
         """
         self.disaggregations = disaggregations
         self.values = {}
+        self.indicator_id = indicator_id
 
 
     def get_disaggregations(self):
@@ -67,8 +70,8 @@ class Series:
             The numerical value to add.
         """
         if year in self.values:
-            warning = '\nWARNING: Duplicate values for year {}: {} and {} in series: {}'
-            print(warning.format(year, value, self.values[year], self.get_disaggregations()))
+            warning = '\nWARNING: {} - Duplicate values for year {}: {} and {} in series: {}'
+            print(warning.format(self.indicator_id, year, value, self.values[year], self.get_disaggregations()))
         else:
             self.values[year] = value
 


### PR DESCRIPTION
This allows builds to complete even when there are issues in the data.