### PR TITLE
Fix call for base class for indicator ids

### DIFF
--- a/sdg/outputs/OutputOpenSdg.py
+++ b/sdg/outputs/OutputOpenSdg.py
@@ -248,7 +248,7 @@ class OutputOpenSdg(OutputBase):
                 continue
             indicator_ids.append(indicator_id)
         if len(indicator_ids) < 1:
-            return OutputBase.get_documentation_indicator_ids()
+            return OutputBase.get_documentation_indicator_ids(self)
         else:
             return indicator_ids
 


### PR DESCRIPTION
This is a minor issue because it would only be a problem when there is no data. But it does come up when compiling an Open SDG starter for the first time, so it would be nice to fix.