### PR TITLE
Output untranslated build along with translation builds

### DIFF
--- a/sdg/open_sdg.py
+++ b/sdg/open_sdg.py
@@ -117,6 +117,8 @@ def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
         if options['languages']:
             # If languages were provide, perform a translated build.
             status = status & output.execute_per_language(options['languages'])
+            # Also provide an untranslated build.
+            status = status & output.execute('untranslated')
         else:
             # Otherwise perform an untranslated build.
             status = status & output.execute()

--- a/sdg/outputs/OutputBase.py
+++ b/sdg/outputs/OutputBase.py
@@ -50,6 +50,10 @@ class OutputBase:
         # Keep a backup of the output folder.
         original_output_folder = self.output_folder
 
+        if language == 'untranslated':
+            self.output_folder = os.path.join(original_output_folder, 'untranslated')
+            language = None
+
         if language:
             # Temporarily change the output folder.
             self.output_folder = os.path.join(original_output_folder, language)


### PR DESCRIPTION
This adds an untranslated build along with the translated builds. Whereas previously the output of translated builds would include a subfolder for each language, now there is an additional subfolder called "untranslated".

This should not change any current behavior/functionality, but it allows for the usage of this untranslated data/metadata. There may be other future uses for this, but at current the first intended use is in an indicator configuration form, which needs to be populated with the untranslated metadata.