### PR TITLE
Use column as a default group when translating data

### DIFF
--- a/sdg/Indicator.py
+++ b/sdg/Indicator.py
@@ -254,8 +254,8 @@ class Indicator:
                 return {key: translate_meta(value) for (key, value) in text.items()}
             # Otherwise treat as a string.
             return translation_helper.translate(text, language, default_group='data')
-        def translate_data(text):
-            return translation_helper.translate(text, language, default_group='data')
+        def translate_data(text, column):
+            return translation_helper.translate(text, language, default_group=[column, 'data'])
         def translate_data_columns(text):
             special_columns = ['Year', 'Value', 'Units']
             if text in special_columns:
@@ -279,7 +279,7 @@ class Indicator:
         # Translate the data cells and headers.
         data_copy = copy.deepcopy(self.data)
         for column in data_copy:
-            data_copy[column] = data_copy[column].apply(translate_data)
+            data_copy[column] = data_copy[column].apply(lambda x: translate_data(x, column))
         data_copy.rename(mapper=translate_data_columns, axis='columns', inplace=True)
         indicator.set_data(data_copy)
 

--- a/sdg/translations/TranslationHelper.py
+++ b/sdg/translations/TranslationHelper.py
@@ -59,10 +59,11 @@ class TranslationHelper(TranslationOutputBase):
             The string of text that may be a translation key (or may not).
         language : string
             The language code to translate into.
-        default_group : None or string
+        default_group : None or string or List
             An optional "group" to add (if needed) to the text. For example, if
             text = "bar" and default_group = "foo", this function will first
-            try "bar", and if nothing is found, try "foo.bar".
+            try "bar", and if nothing is found, try "foo.bar". Can also be a list
+            of groups, which will all be attempted.
 
         Returns
         -------
@@ -75,8 +76,16 @@ class TranslationHelper(TranslationOutputBase):
         # Add the default_group if necessary.
         key = text
         if not self.is_translation_key(key):
-            if default_group:
-                key = default_group + "." + key
+            if default_group is not None:
+                if isinstance(default_group, str):
+                    key = default_group + "." + key
+                elif isinstance(default_group, list):
+                    for group in default_group:
+                        potential_key = group + "." + key
+                        if self.is_translation_key(potential_key):
+                            key = potential_key
+                            break
+
         # If it is not translated, return the original.
         if not self.is_translation_key(key):
             return text


### PR DESCRIPTION
Right now, when translating data, `data` is always used as the default group. For example, if a cell contains `foo` then it will be translated as if it were a "translation key" of `data.foo`. This PR first tries to use the column name as the default group, while still falling back to `data`. For example, if a cell in the `baz` column contains `foo`, then it will be translated as if were `baz.foo`, or if that doesn't work, `data.foo`.
