### PR TITLE
Disaggregation stats in Open SDG output

### DIFF
--- a/sdg/DisaggregationStatusService.py
+++ b/sdg/DisaggregationStatusService.py
@@ -77,7 +77,7 @@ class DisaggregationStatusService:
         status = {
             'statuses': [{
                 'value': 'fully_dissaggregated',
-                'translation_key': 'status.fully_disaggregated',
+                'translation_key': 'Fully disaggregated',
             }],
             'overall': {
                 'statuses': [],
@@ -131,7 +131,7 @@ class DisaggregationStatusService:
         status['overall']['totals']['total'] = overall_total
         status['overall']['statuses'].append({
             'status': 'fully_disaggregated',
-            'translation_key': 'status.fully_disaggregated',
+            'translation_key': 'Fully disaggregated',
             'count': overall_fully_disaggregated,
             'percentage': self.get_percent(overall_fully_disaggregated, overall_total)
         })
@@ -143,8 +143,8 @@ class DisaggregationStatusService:
             status['goals'].append({
                 'goal': goal_id,
                 'statuses': [{
-                    'status': 'fully_dissaggregated',
-                    'translation_key': 'status.fully_disaggregated',
+                    'status': 'fully_disaggregated',
+                    'translation_key': 'Fully disaggregated',
                     'count': num_fully_disaggregated,
                     'percentage': self.get_percent(num_fully_disaggregated, num_total),
                 }],
@@ -162,7 +162,7 @@ class DisaggregationStatusService:
                     extra_field: extra_field_value,
                     'statuses': [{
                         'status': 'fully_dissaggregated',
-                        'translation_key': 'status.fully_disaggregated',
+                        'translation_key': 'Fully disaggregated',
                         'count': num_fully_disaggregated,
                         'percentage': self.get_percent(num_fully_disaggregated, num_total),
                     }],

--- a/sdg/DisaggregationStatusService.py
+++ b/sdg/DisaggregationStatusService.py
@@ -75,10 +75,16 @@ class DisaggregationStatusService:
     def get_stats(self):
 
         status = {
-            'statuses': [{
-                'value': 'fully_disaggregated',
-                'translation_key': 'Fully disaggregated',
-            }],
+            'statuses': [
+                {
+                    'value': 'fully_disaggregated',
+                    'translation_key': 'Fully disaggregated',
+                },
+                {
+                    'value': 'not_disaggregated',
+                    'translation_key': 'Not disaggregated',
+                },
+            ],
             'overall': {
                 'statuses': [],
                 'totals': {
@@ -92,6 +98,7 @@ class DisaggregationStatusService:
             goals[goal] = {
                 'total': 0,
                 'fully_disaggregated': 0,
+                'not_disaggregated': 0,
             }
 
         extra_fields = {}
@@ -100,6 +107,7 @@ class DisaggregationStatusService:
 
         overall_total = 0
         overall_fully_disaggregated = 0
+        overall_not_disaggregated = 0
 
         for indicator_id in self.indicators:
             indicator = self.indicators[indicator_id]
@@ -117,6 +125,7 @@ class DisaggregationStatusService:
                             extra_fields[extra_field][extra_field_value] = {
                                 'total': 0,
                                 'fully_disaggregated': 0,
+                                'not_disaggregated': 0,
                             }
                         extra_fields[extra_field][extra_field_value]['total'] += 1
 
@@ -127,6 +136,13 @@ class DisaggregationStatusService:
                     extra_field_value = indicator.get_meta_field_value(extra_field)
                     if extra_field_value is not None:
                         extra_fields[extra_field][extra_field_value]['fully_disaggregated'] += 1
+            else:
+                overall_not_disaggregated += 1
+                goals[goal_id]['not_disaggregated'] += 1
+                for extra_field in self.extra_fields:
+                    extra_field_value = indicator.get_meta_field_value(extra_field)
+                    if extra_field_value is not None:
+                        extra_fields[extra_field][extra_field_value]['not_disaggregated'] += 1
 
         status['overall']['totals']['total'] = overall_total
         status['overall']['statuses'].append({
@@ -135,19 +151,34 @@ class DisaggregationStatusService:
             'count': overall_fully_disaggregated,
             'percentage': self.get_percent(overall_fully_disaggregated, overall_total)
         })
+        status['overall']['statuses'].append({
+            'status': 'not_disaggregated',
+            'translation_key': 'Not disaggregated',
+            'count': overall_not_disaggregated,
+            'percentage': self.get_percent(overall_not_disaggregated, overall_total)
+        })
 
         status['goals'] = []
         for goal_id in goals:
             num_fully_disaggregated = goals[goal_id]['fully_disaggregated']
+            num_not_disaggregated = goals[goal_id]['not_disaggregated']
             num_total = goals[goal_id]['total']
             status['goals'].append({
                 'goal': goal_id,
-                'statuses': [{
-                    'status': 'fully_disaggregated',
-                    'translation_key': 'Fully disaggregated',
-                    'count': num_fully_disaggregated,
-                    'percentage': self.get_percent(num_fully_disaggregated, num_total),
-                }],
+                'statuses': [
+                    {
+                        'status': 'fully_disaggregated',
+                        'translation_key': 'Fully disaggregated',
+                        'count': num_fully_disaggregated,
+                        'percentage': self.get_percent(num_fully_disaggregated, num_total),
+                    },
+                    {
+                        'status': 'not_disaggregated',
+                        'translation_key': 'Not disaggregated',
+                        'count': num_not_disaggregated,
+                        'percentage': self.get_percent(num_not_disaggregated, num_total),
+                    },
+                ],
                 'totals': {
                     'total': num_total
                 }
@@ -157,15 +188,24 @@ class DisaggregationStatusService:
             status['extra_fields'][extra_field] = []
             for extra_field_value in extra_fields[extra_field]:
                 num_fully_disaggregated = extra_fields[extra_field][extra_field_value]['fully_disaggregated']
+                num_not_disaggregated = extra_fields[extra_field][extra_field_value]['not_disaggregated']
                 num_total = extra_fields[extra_field][extra_field_value]['total']
                 status['extra_fields'][extra_field].append({
                     extra_field: extra_field_value,
-                    'statuses': [{
-                        'status': 'fully_disaggregated',
-                        'translation_key': 'Fully disaggregated',
-                        'count': num_fully_disaggregated,
-                        'percentage': self.get_percent(num_fully_disaggregated, num_total),
-                    }],
+                    'statuses': [
+                        {
+                            'status': 'fully_disaggregated',
+                            'translation_key': 'Fully disaggregated',
+                            'count': num_fully_disaggregated,
+                            'percentage': self.get_percent(num_fully_disaggregated, num_total),
+                        },
+                        {
+                            'status': 'not_disaggregated',
+                            'translation_key': 'Not disaggregated',
+                            'count': num_not_disaggregated,
+                            'percentage': self.get_percent(num_not_disaggregated, num_total),
+                        },
+                    ],
                     'totals': {
                         'total': num_total
                     }

--- a/sdg/DisaggregationStatusService.py
+++ b/sdg/DisaggregationStatusService.py
@@ -83,6 +83,11 @@ class DisaggregationStatusService:
         return False
 
 
+    def is_indicator_notapplicable(self, indicator_id):
+        expected = self.expected_disaggregations[indicator_id]
+        return len(expected) == 0
+
+
     def get_stats(self):
 
         status = {
@@ -134,7 +139,7 @@ class DisaggregationStatusService:
 
         for indicator_id in self.indicators:
             indicator = self.indicators[indicator_id]
-            is_statistical = indicator.is_statistical()
+            is_notapplicable = self.is_indicator_notapplicable(indicator_id)
             is_complete = self.is_indicator_complete(indicator_id)
             is_inprogress = self.is_indicator_inprogress(indicator_id)
             goal_id = int(indicator.get_goal_id())
@@ -142,7 +147,7 @@ class DisaggregationStatusService:
             overall_total += 1
             goals[goal_id]['total'] += 1
 
-            if not is_statistical:
+            if is_notapplicable:
                 goals[goal_id]['notapplicable'] += 1
                 overall_notapplicable += 1
             elif is_complete:
@@ -167,7 +172,7 @@ class DisaggregationStatusService:
                             'notapplicable': 0,
                         }
                     extra_fields[extra_field][extra_field_value]['total'] += 1
-                    if not is_statistical:
+                    if is_notapplicable:
                         extra_fields[extra_field][extra_field_value]['notapplicable'] += 1
                     elif is_complete:
                         extra_fields[extra_field][extra_field_value]['complete'] += 1

--- a/sdg/DisaggregationStatusService.py
+++ b/sdg/DisaggregationStatusService.py
@@ -100,7 +100,7 @@ class DisaggregationStatusService:
                     'translation_key': 'Not yet disaggregated',
                 },
                 {
-                    'value': 'out_of_scope',
+                    'value': 'notapplicable',
                     'translation_key': 'Out of scope',
                 },
             ],
@@ -119,7 +119,7 @@ class DisaggregationStatusService:
                 'fully_disaggregated': 0,
                 'partially_disaggregated': 0,
                 'not_disaggregated': 0,
-                'out_of_scope': 0,
+                'notapplicable': 0,
             }
 
         extra_fields = {}
@@ -130,7 +130,7 @@ class DisaggregationStatusService:
         overall_fully_disaggregated = 0
         overall_partially_disaggregated = 0
         overall_not_disaggregated = 0
-        overall_out_of_scope = 0
+        overall_notapplicable = 0
 
         for indicator_id in self.indicators:
             indicator = self.indicators[indicator_id]
@@ -143,8 +143,8 @@ class DisaggregationStatusService:
             goals[goal_id]['total'] += 1
 
             if not is_statistical:
-                goals[goal_id]['out_of_scope'] += 1
-                overall_out_of_scope += 1
+                goals[goal_id]['notapplicable'] += 1
+                overall_notapplicable += 1
             elif is_fully_disaggregated:
                 goals[goal_id]['fully_disaggregated'] += 1
                 overall_fully_disaggregated += 1
@@ -164,11 +164,11 @@ class DisaggregationStatusService:
                             'fully_disaggregated': 0,
                             'partially_disaggregated': 0,
                             'not_disaggregated': 0,
-                            'out_of_scope': 0,
+                            'notapplicable': 0,
                         }
                     extra_fields[extra_field][extra_field_value]['total'] += 1
                     if not is_statistical:
-                        extra_fields[extra_field][extra_field_value]['out_of_scope'] += 1
+                        extra_fields[extra_field][extra_field_value]['notapplicable'] += 1
                     elif is_fully_disaggregated:
                         extra_fields[extra_field][extra_field_value]['fully_disaggregated'] += 1
                     elif is_partially_disaggregated:
@@ -196,10 +196,10 @@ class DisaggregationStatusService:
             'percentage': self.get_percent(overall_not_disaggregated, overall_total)
         })
         status['overall']['statuses'].append({
-            'status': 'out_of_scope',
+            'status': 'notapplicable',
             'translation_key': 'Out of scope',
-            'count': overall_out_of_scope,
-            'percentage': self.get_percent(overall_out_of_scope, overall_total)
+            'count': overall_notapplicable,
+            'percentage': self.get_percent(overall_notapplicable, overall_total)
         })
 
         status['goals'] = []
@@ -207,7 +207,7 @@ class DisaggregationStatusService:
             num_fully_disaggregated = goals[goal_id]['fully_disaggregated']
             num_partially_disaggregated = goals[goal_id]['partially_disaggregated']
             num_not_disaggregated = goals[goal_id]['not_disaggregated']
-            num_out_of_scope = goals[goal_id]['out_of_scope']
+            num_notapplicable = goals[goal_id]['notapplicable']
             num_total = goals[goal_id]['total']
             status['goals'].append({
                 'goal': goal_id,
@@ -231,10 +231,10 @@ class DisaggregationStatusService:
                         'percentage': self.get_percent(num_not_disaggregated, num_total),
                     },
                     {
-                        'status': 'out_of_scope',
+                        'status': 'notapplicable',
                         'translation_key': 'Out of scope',
-                        'count': num_out_of_scope,
-                        'percentage': self.get_percent(num_out_of_scope, num_total)
+                        'count': num_notapplicable,
+                        'percentage': self.get_percent(num_notapplicable, num_total)
                     },
                 ],
                 'totals': {
@@ -248,7 +248,7 @@ class DisaggregationStatusService:
                 num_fully_disaggregated = extra_fields[extra_field][extra_field_value]['fully_disaggregated']
                 num_partially_disaggregated = extra_fields[extra_field][extra_field_value]['partially_disaggregated']
                 num_not_disaggregated = extra_fields[extra_field][extra_field_value]['not_disaggregated']
-                num_out_of_scope = extra_fields[extra_field][extra_field_value]['out_of_scope']
+                num_notapplicable = extra_fields[extra_field][extra_field_value]['notapplicable']
                 num_total = extra_fields[extra_field][extra_field_value]['total']
                 status['extra_fields'][extra_field].append({
                     extra_field: extra_field_value,
@@ -272,10 +272,10 @@ class DisaggregationStatusService:
                             'percentage': self.get_percent(num_not_disaggregated, num_total),
                         },
                         {
-                            'status': 'out_of_scope',
+                            'status': 'notapplicable',
                             'translation_key': 'Out of scope',
-                            'count': num_out_of_scope,
-                            'percentage': self.get_percent(num_out_of_scope, num_total),
+                            'count': num_notapplicable,
+                            'percentage': self.get_percent(num_notapplicable, num_total),
                         },
                     ],
                     'totals': {

--- a/sdg/DisaggregationStatusService.py
+++ b/sdg/DisaggregationStatusService.py
@@ -82,7 +82,7 @@ class DisaggregationStatusService:
                 },
                 {
                     'value': 'not_disaggregated',
-                    'translation_key': 'Not disaggregated',
+                    'translation_key': 'Not fully disaggregated',
                 },
             ],
             'overall': {
@@ -153,7 +153,7 @@ class DisaggregationStatusService:
         })
         status['overall']['statuses'].append({
             'status': 'not_disaggregated',
-            'translation_key': 'Not disaggregated',
+            'translation_key': 'Not fully disaggregated',
             'count': overall_not_disaggregated,
             'percentage': self.get_percent(overall_not_disaggregated, overall_total)
         })
@@ -174,7 +174,7 @@ class DisaggregationStatusService:
                     },
                     {
                         'status': 'not_disaggregated',
-                        'translation_key': 'Not disaggregated',
+                        'translation_key': 'Not fully disaggregated',
                         'count': num_not_disaggregated,
                         'percentage': self.get_percent(num_not_disaggregated, num_total),
                     },
@@ -201,7 +201,7 @@ class DisaggregationStatusService:
                         },
                         {
                             'status': 'not_disaggregated',
-                            'translation_key': 'Not disaggregated',
+                            'translation_key': 'Not fully disaggregated',
                             'count': num_not_disaggregated,
                             'percentage': self.get_percent(num_not_disaggregated, num_total),
                         },

--- a/sdg/DisaggregationStatusService.py
+++ b/sdg/DisaggregationStatusService.py
@@ -1,0 +1,94 @@
+import os
+import sdg
+import json
+
+class DisaggregationStatusService:
+    """Service to calculate to what extent the data is disaggregated."""
+
+
+    def __init__(self, site_dir, indicators):
+        """Constructor for the DisaggregationStatusService class.
+
+        Parameters
+        ----------
+        site_dir : string
+            Base folder in which to write files.
+        indicators : dict
+            Dict of Indicator objects keyed by indicator id.
+        """
+        self.site_dir = site_dir
+        self.indicators = indicators
+        self.expected_disaggregations = self.get_expected_disaggregations()
+        self.actual_disaggregations = self.get_expected_disaggregations()
+
+
+    def get_expected_disaggregations(self):
+        indicators = {}
+        for indicator_id in self.indicators:
+            indicator = self.indicators[indicator_id]
+            disaggregations = indicator.get_meta_field_value('expected_disaggregations')
+            if disaggregations is None:
+                disaggregations = []
+            indicators[indicator_id] = disaggregations
+        return indicators
+
+
+    def get_actual_disaggregations(self):
+        indicators = {}
+        for indicator_id in self.indicators:
+            indicator = self.indicators[indicator_id]
+            if not indicator.has_data():
+                indicators[indicator_id] = []
+                continue
+            non_disaggregation_columns = indicator.options.get_non_disaggregation_columns()
+            disaggregations = [column for column in indicator.data.columns if column not in non_disaggregation_columns]
+            indicators[indicator_id] = disaggregations
+        return indicators
+
+
+    def is_indicator_fully_disaggregated(self, indicator_id):
+        num_expected = len(self.expected_disaggregations[indicator_id])
+        num_actual = len(self.actual_disaggregations[indicator_id])
+        return num_actual - num_expected >= 0
+
+
+    def get_number_of_fully_disaggregated_indicators(self):
+        num_disaggregated = 0
+        for indicator_id in self.indicators:
+            indicator = self.indicators[indicator_id]
+            if indicator.is_statistical() and self.is_indicator_fully_disaggregated(indicator_id):
+                num_disaggregated += 1
+
+        return num_disaggregated
+
+
+    def get_number_of_statistical_indicators(self):
+        num_statistical = 0
+        for indicator_id in self.indicators:
+            indicator = self.indicators[indicator_id]
+            if indicator.is_statistical():
+                num_statistical += 1
+        return num_statistical
+
+
+    def get_percentage_of_full_disaggregation(self):
+        num_total = self.get_number_of_statistical_indicators()
+        num_disaggregated = self.get_number_of_fully_disaggregated_indicators()
+        return 100 * float(num_disaggregated)/float(num_total)
+
+
+    def get_stats(self):
+        return {
+            'num_fully_disaggregated': self.get_number_of_fully_disaggregated_indicators(),
+            'num_statistical': self.get_number_of_statistical_indicators(),
+            'percent_fully_disaggregated': self.get_percentage_of_full_disaggregation(),
+        }
+
+
+    def write_json(self):
+        folder = os.path.join(self.site_dir, 'stats')
+        if not os.path.exists(folder):
+            os.makedirs(folder, exist_ok=True)
+        json_path = os.path.join(folder, 'disaggregation.json')
+        with open(json_path, 'w', encoding='utf-8') as outfile:
+            json.dump(self.get_stats(), outfile)

--- a/sdg/DisaggregationStatusService.py
+++ b/sdg/DisaggregationStatusService.py
@@ -136,7 +136,7 @@ class DisaggregationStatusService:
                     extra_field_value = indicator.get_meta_field_value(extra_field)
                     if extra_field_value is not None:
                         extra_fields[extra_field][extra_field_value]['fully_disaggregated'] += 1
-            else:
+            elif is_statistical:
                 overall_not_disaggregated += 1
                 goals[goal_id]['not_disaggregated'] += 1
                 for extra_field in self.extra_fields:

--- a/sdg/DisaggregationStatusService.py
+++ b/sdg/DisaggregationStatusService.py
@@ -76,7 +76,7 @@ class DisaggregationStatusService:
 
         status = {
             'statuses': [{
-                'value': 'fully_dissaggregated',
+                'value': 'fully_disaggregated',
                 'translation_key': 'Fully disaggregated',
             }],
             'overall': {
@@ -161,7 +161,7 @@ class DisaggregationStatusService:
                 status['extra_fields'][extra_field].append({
                     extra_field: extra_field_value,
                     'statuses': [{
-                        'status': 'fully_dissaggregated',
+                        'status': 'fully_disaggregated',
                         'translation_key': 'Fully disaggregated',
                         'count': num_fully_disaggregated,
                         'percentage': self.get_percent(num_fully_disaggregated, num_total),

--- a/sdg/DisaggregationStatusService.py
+++ b/sdg/DisaggregationStatusService.py
@@ -19,7 +19,7 @@ class DisaggregationStatusService:
         self.site_dir = site_dir
         self.indicators = indicators
         self.expected_disaggregations = self.get_expected_disaggregations()
-        self.actual_disaggregations = self.get_expected_disaggregations()
+        self.actual_disaggregations = self.get_actual_disaggregations()
 
 
     def get_expected_disaggregations(self):

--- a/sdg/DisaggregationStatusService.py
+++ b/sdg/DisaggregationStatusService.py
@@ -47,9 +47,14 @@ class DisaggregationStatusService:
 
 
     def is_indicator_fully_disaggregated(self, indicator_id):
-        num_expected = len(self.expected_disaggregations[indicator_id])
-        num_actual = len(self.actual_disaggregations[indicator_id])
-        return num_actual - num_expected >= 0
+        expected = self.expected_disaggregations[indicator_id]
+        actual = self.actual_disaggregations[indicator_id]
+        if len(actual) < len(expected):
+            return False
+        for disaggregation in expected:
+            if disaggregation not in actual:
+                return False
+        return True
 
 
     def get_number_of_fully_disaggregated_indicators(self):

--- a/sdg/DisaggregationStatusService.py
+++ b/sdg/DisaggregationStatusService.py
@@ -94,19 +94,19 @@ class DisaggregationStatusService:
             'statuses': [
                 {
                     'value': 'complete',
-                    'translation_key': 'Fully disaggregated',
+                    'translation_key': 'status.disaggregation_status_complete',
                 },
                 {
                     'value': 'inprogress',
-                    'translation_key': 'Partially disaggregated',
+                    'translation_key': 'status.disaggregation_status_inprogress',
                 },
                 {
                     'value': 'notstarted',
-                    'translation_key': 'Not yet disaggregated',
+                    'translation_key': 'status.disaggregation_status_notstarted',
                 },
                 {
                     'value': 'notapplicable',
-                    'translation_key': 'Out of scope',
+                    'translation_key': 'status.disaggregation_status_notapplicable',
                 },
             ],
             'overall': {
@@ -184,25 +184,25 @@ class DisaggregationStatusService:
         status['overall']['totals']['total'] = overall_total
         status['overall']['statuses'].append({
             'status': 'complete',
-            'translation_key': 'Fully disaggregated',
+            'translation_key': 'status.disaggregation_status_complete',
             'count': overall_complete,
             'percentage': self.get_percent(overall_complete, overall_total)
         })
         status['overall']['statuses'].append({
             'status': 'inprogress',
-            'translation_key': 'Partially disaggregated',
+            'translation_key': 'status.disaggregation_status_inprogress',
             'count': overall_inprogress,
             'percentage': self.get_percent(overall_inprogress, overall_total)
         })
         status['overall']['statuses'].append({
             'status': 'notstarted',
-            'translation_key': 'Not fully disaggregated',
+            'translation_key': 'status.disaggregation_status_notstarted',
             'count': overall_notstarted,
             'percentage': self.get_percent(overall_notstarted, overall_total)
         })
         status['overall']['statuses'].append({
             'status': 'notapplicable',
-            'translation_key': 'Out of scope',
+            'translation_key': 'status.disaggregation_status_notapplicable',
             'count': overall_notapplicable,
             'percentage': self.get_percent(overall_notapplicable, overall_total)
         })
@@ -219,25 +219,25 @@ class DisaggregationStatusService:
                 'statuses': [
                     {
                         'status': 'complete',
-                        'translation_key': 'Fully disaggregated',
+                        'translation_key': 'status.disaggregation_status_complete',
                         'count': num_complete,
                         'percentage': self.get_percent(num_complete, num_total),
                     },
                     {
                         'status': 'inprogress',
-                        'translation_key': 'Partially disaggregated',
+                        'translation_key': 'status.disaggregation_status_inprogress',
                         'count': num_inprogress,
                         'percentage': self.get_percent(num_inprogress, num_total)
                     },
                     {
                         'status': 'notstarted',
-                        'translation_key': 'Not fully disaggregated',
+                        'translation_key': 'status.disaggregation_status_notstarted',
                         'count': num_notstarted,
                         'percentage': self.get_percent(num_notstarted, num_total),
                     },
                     {
                         'status': 'notapplicable',
-                        'translation_key': 'Out of scope',
+                        'translation_key': 'status.disaggregation_status_notapplicable',
                         'count': num_notapplicable,
                         'percentage': self.get_percent(num_notapplicable, num_total)
                     },
@@ -260,25 +260,25 @@ class DisaggregationStatusService:
                     'statuses': [
                         {
                             'status': 'complete',
-                            'translation_key': 'Fully disaggregated',
+                            'translation_key': 'status.disaggregation_status_complete',
                             'count': num_complete,
                             'percentage': self.get_percent(num_complete, num_total),
                         },
                         {
                             'status': 'inprogress',
-                            'translation_key': 'Partially disaggregated',
+                            'translation_key': 'status.disaggregation_status_inprogress',
                             'count': num_inprogress,
                             'percentage': self.get_percent(num_inprogress, num_total),
                         },
                         {
                             'status': 'notstarted',
-                            'translation_key': 'Not fully disaggregated',
+                            'translation_key': 'status.disaggregation_status_notstarted',
                             'count': num_notstarted,
                             'percentage': self.get_percent(num_notstarted, num_total),
                         },
                         {
                             'status': 'notapplicable',
-                            'translation_key': 'Out of scope',
+                            'translation_key': 'status.disaggregation_status_notapplicable',
                             'count': num_notapplicable,
                             'percentage': self.get_percent(num_notapplicable, num_total),
                         },

--- a/sdg/DisaggregationStatusService.py
+++ b/sdg/DisaggregationStatusService.py
@@ -71,17 +71,19 @@ class DisaggregationStatusService:
         return num_statistical
 
 
-    def get_percentage_of_full_disaggregation(self):
-        num_total = self.get_number_of_statistical_indicators()
-        num_disaggregated = self.get_number_of_fully_disaggregated_indicators()
-        return 100 * float(num_disaggregated)/float(num_total)
-
-
     def get_stats(self):
+        total = self.get_number_of_statistical_indicators()
+        disaggregated = self.get_number_of_fully_disaggregated_indicators()
+        not_disaggregated = total - disaggregated
+        disaggregated_percent = 100 * float(disaggregated) / float(total)
+        not_disaggregated_percent = 100 * float(not_disaggregated) / float(total)
+
         return {
-            'num_fully_disaggregated': self.get_number_of_fully_disaggregated_indicators(),
-            'num_statistical': self.get_number_of_statistical_indicators(),
-            'percent_fully_disaggregated': self.get_percentage_of_full_disaggregation(),
+            'total': total,
+            'disaggregated': disaggregated,
+            'not_disaggregated': not_disaggregated,
+            'disaggregated_percent': disaggregated_percent,
+            'not_disaggregated_percent': not_disaggregated_percent,
         }
 
 

--- a/sdg/__init__.py
+++ b/sdg/__init__.py
@@ -15,6 +15,7 @@ from . import outputs
 from . import schemas
 from . import translations
 from .DisaggregationReportService import DisaggregationReportService
+from .DisaggregationStatusService import DisaggregationStatusService
 from .OutputDocumentationService import OutputDocumentationService
 from .Indicator import Indicator
 from .IndicatorExportService import IndicatorExportService

--- a/sdg/outputs/OutputOpenSdg.py
+++ b/sdg/outputs/OutputOpenSdg.py
@@ -82,6 +82,9 @@ class OutputOpenSdg(OutputBase):
         stats_reporting = sdg.stats.reporting_status(self.schema, all_meta, self.reporting_status_grouping_fields)
         status = status & sdg.json.write_json('reporting', stats_reporting, ftype='stats', site_dir=site_dir)
 
+        disaggregation_status_service = sdg.DisaggregationStatusService(site_dir, self.indicators)
+        disaggregation_status_service.write_json()
+
         indicator_export_service = sdg.IndicatorExportService(site_dir, self.indicators)
         indicator_export_service.export_all_indicator_data_as_zip_archive()
 

--- a/sdg/outputs/OutputOpenSdg.py
+++ b/sdg/outputs/OutputOpenSdg.py
@@ -82,7 +82,7 @@ class OutputOpenSdg(OutputBase):
         stats_reporting = sdg.stats.reporting_status(self.schema, all_meta, self.reporting_status_grouping_fields)
         status = status & sdg.json.write_json('reporting', stats_reporting, ftype='stats', site_dir=site_dir)
 
-        disaggregation_status_service = sdg.DisaggregationStatusService(site_dir, self.indicators)
+        disaggregation_status_service = sdg.DisaggregationStatusService(site_dir, self.indicators, self.reporting_status_grouping_fields)
         disaggregation_status_service.write_json()
 
         indicator_export_service = sdg.IndicatorExportService(site_dir, self.indicators)


### PR DESCRIPTION
This adds an "endpoint" at /stats/disaggregation.json to the Open SDG output. This includes the following data:

* disaggregated: Number of indicators that are fully disaggregated
* not_disaggregated: Number of indicators that are not fully disaggregated
* total: Number of statistical indicators (this will be equal to the total of "disaggregated" and "not_disaggregated")
* disaggregated_percent: Percentage of indicators that are fully disaggregated (percentage of "total")
* not_disaggregated_percent: Percentage of indicators that are not fully disaggregated (percentage of "total")

The way that it determines "fully disaggregated" is dependent on a metadata field called `expected_disaggregations`, which should be a list of column names.

For example, if an indicator is expected to be disaggregated by "Age" and "Sex", then this metadata field should be something like (in YAML):

```
expected_disaggregations:
  - Age
  - Sex
```

If the indicator's data itself has both an `Age` and a `Sex` column, then it is considered "fully disaggregated".

If an indicator does not have an `expected_disaggregations` metadata field, then it will automatically be considered fully disaggregated.

The next step is to add code to Open SDG to use this data.