### PR TITLE
Yaml meta input

### DIFF
--- a/sdg/inputs/InputYamlMeta.py
+++ b/sdg/inputs/InputYamlMeta.py
@@ -1,0 +1,15 @@
+from sdg.inputs import InputMetaFiles
+import yaml
+
+
+class InputYamlMeta(InputMetaFiles):
+    """Sources of SDG metadata that are local YAML files."""
+
+    def read_meta_at_path(self, filepath):
+
+        meta = {}
+
+        with open(filepath, 'r', encoding='utf-8') as stream:
+            meta = yaml.load(stream, Loader=yaml.FullLoader)
+
+        return meta

--- a/sdg/inputs/__init__.py
+++ b/sdg/inputs/__init__.py
@@ -5,6 +5,7 @@ from .InputCsvMeta import InputCsvMeta
 from .InputExcelMeta import InputExcelMeta
 from .InputCsvData import InputCsvData
 from .InputYamlMdMeta import InputYamlMdMeta
+from .InputYamlMeta import InputYamlMeta
 from .InputSdmx import InputSdmx
 from .InputSdmxJson import InputSdmxJson
 from .InputSdmxMl_Structure import InputSdmxMl_Structure

--- a/sdg/open_sdg.py
+++ b/sdg/open_sdg.py
@@ -314,6 +314,7 @@ def open_sdg_input_from_dict(params, options):
         'InputYamlMdMeta',
         'InputSdmxMl_Multiple',
         'InputExcelMeta',
+        'InputYamlMeta',
     ]
     if input_class not in allowed:
         raise KeyError("Input class '%s' is not one of: %s." % (input_class, ', '.join(allowed)))
@@ -344,6 +345,8 @@ def open_sdg_input_from_dict(params, options):
         input_instance = sdg.inputs.InputSdmxMl_Multiple(**params)
     elif input_class == 'InputExcelMeta':
         input_instance = sdg.inputs.InputExcelMeta(**params)
+    elif input_class == 'InputYamlMeta':
+        input_instance = sdg.inputs.InputYamlMeta(**params)
 
     return input_instance
 


### PR DESCRIPTION
@jwestw @LucyGwilliamAdmin This is another PR needed for the site/indicator config forms. This adds an input for metadata that is in plain YAML - as opposed to the one we already have that supports a YAML + Markdown combination. In other words, this one uses YAML files that don't have the `---` section at the bottom.