### PR TITLE
Output documentation baseurl

### DIFF
--- a/sdg/OutputDocumentationService.py
+++ b/sdg/OutputDocumentationService.py
@@ -51,7 +51,7 @@ class OutputDocumentationService:
         self.branding = branding
         self.intro = intro
         self.indicator_url = indicator_url
-        self.baseurl = baseurl
+        self.baseurl = self.fix_baseurl(baseurl)
         self.slugs = []
         self.languages = ['en'] if languages is None else languages
         if translations is not None:
@@ -64,6 +64,17 @@ class OutputDocumentationService:
             translation_helper = self.translation_helper,
             indicator_url = self.indicator_url
         )
+
+
+    def fix_baseurl(self, baseurl):
+        if baseurl is None or baseurl == '':
+            return ''
+        # Make sure the baseurl starts and ends with a slash.
+        if not baseurl.startswith('/'):
+            baseurl = '/' + baseurl
+        if not baseurl.endswith('/'):
+            baseurl = baseurl + '/'
+        return baseurl
 
 
     def generate_documentation(self):

--- a/sdg/OutputDocumentationService.py
+++ b/sdg/OutputDocumentationService.py
@@ -91,6 +91,8 @@ class OutputDocumentationService:
             fixed = fixed + '/'
         if subfolder is not None and subfolder != '':
             fixed = fixed + subfolder
+        if not fixed.endswith('/'):
+            fixed = fixed + '/'
         return fixed
 
 

--- a/sdg/OutputDocumentationService.py
+++ b/sdg/OutputDocumentationService.py
@@ -15,7 +15,7 @@ class OutputDocumentationService:
 
     def __init__(self, outputs, folder='_site', branding='Build docs',
                  languages=None, intro='', translations=None, indicator_url=None,
-                 baseurl=''):
+                 subfolder=None, baseurl=''):
         """Constructor for the OutputDocumentationService class.
 
         Parameters
@@ -26,6 +26,9 @@ class OutputDocumentationService:
         folder : string
             Optional folder in which to create the documentation pages. Defaults
             to the "_site" folder.
+        subfolder : string
+            Optional subfolder (beneath the "folder" parameter) in which to
+            create the documentation pages.
         branding : string
             Optional title/heading to use on all documentation pages. Defaults
             to "Build docs".
@@ -47,11 +50,11 @@ class OutputDocumentationService:
             An optional path that all absolute URLs in the data repository start with.
         """
         self.outputs = outputs
-        self.folder = folder
+        self.folder = self.fix_folder(folder, subfolder)
         self.branding = branding
         self.intro = intro
         self.indicator_url = indicator_url
-        self.baseurl = self.fix_baseurl(baseurl)
+        self.baseurl = self.fix_baseurl(baseurl, subfolder)
         self.slugs = []
         self.languages = ['en'] if languages is None else languages
         if translations is not None:
@@ -66,15 +69,29 @@ class OutputDocumentationService:
         )
 
 
-    def fix_baseurl(self, baseurl):
+    def fix_folder(self, folder, subfolder):
+        fixed = '_site'
+        if folder is not None:
+            fixed = folder
+        if subfolder is not None and subfolder != '':
+            fixed = os.path.join(fixed, subfolder)
+        return fixed
+
+
+    def fix_baseurl(self, baseurl, subfolder):
+        fixed = ''
         if baseurl is None or baseurl == '':
+            # All links will be relative.
             return ''
+        fixed = baseurl
         # Make sure the baseurl starts and ends with a slash.
-        if not baseurl.startswith('/'):
-            baseurl = '/' + baseurl
-        if not baseurl.endswith('/'):
-            baseurl = baseurl + '/'
-        return baseurl
+        if not fixed.startswith('/'):
+            fixed = '/' + fixed
+        if not fixed.endswith('/'):
+            fixed = fixed + '/'
+        if subfolder is not None and subfolder != '':
+            fixed = fixed + subfolder
+        return fixed
 
 
     def generate_documentation(self):

--- a/sdg/OutputDocumentationService.py
+++ b/sdg/OutputDocumentationService.py
@@ -54,7 +54,8 @@ class OutputDocumentationService:
         self.branding = branding
         self.intro = intro
         self.indicator_url = indicator_url
-        self.baseurl = self.fix_baseurl(baseurl, subfolder)
+        self.data_baseurl = self.get_data_baseurl(baseurl)
+        self.docs_baseurl = self.get_docs_baseurl(baseurl, subfolder)
         self.slugs = []
         self.languages = ['en'] if languages is None else languages
         if translations is not None:
@@ -78,7 +79,21 @@ class OutputDocumentationService:
         return fixed
 
 
-    def fix_baseurl(self, baseurl, subfolder):
+    def get_data_baseurl(self, baseurl):
+        fixed = ''
+        if baseurl is None or baseurl == '':
+            # All links will be relative.
+            return ''
+        fixed = baseurl
+        # Make sure the baseurl starts and ends with a slash.
+        if not fixed.startswith('/'):
+            fixed = '/' + fixed
+        if not fixed.endswith('/'):
+            fixed = fixed + '/'
+        return fixed
+
+
+    def get_docs_baseurl(self, baseurl, subfolder):
         fixed = ''
         if baseurl is None or baseurl == '':
             # All links will be relative.
@@ -104,7 +119,7 @@ class OutputDocumentationService:
             pages.append({
                 'title': title,
                 'filename': self.create_filename(title),
-                'content': output.get_documentation_content(self.languages, self.baseurl),
+                'content': output.get_documentation_content(self.languages, self.data_baseurl),
                 'description': output.get_documentation_description()
             })
             extras = output.get_documentation_extras()
@@ -333,7 +348,7 @@ class OutputDocumentationService:
             }});</script>
         </html>
         """
-        return template.format(branding=self.branding, title=title, content=content, baseurl=self.baseurl)
+        return template.format(branding=self.branding, title=title, content=content, baseurl=self.docs_baseurl)
 
 
     def html_from_dataframe(self, df, escape=False, totals=True):

--- a/sdg/OutputDocumentationService.py
+++ b/sdg/OutputDocumentationService.py
@@ -14,7 +14,8 @@ class OutputDocumentationService:
 
 
     def __init__(self, outputs, folder='_site', branding='Build docs',
-                 languages=None, intro='', translations=None, indicator_url=None):
+                 languages=None, intro='', translations=None, indicator_url=None,
+                 baseurl=''):
         """Constructor for the OutputDocumentationService class.
 
         Parameters
@@ -42,12 +43,15 @@ class OutputDocumentationService:
             the "[id]" will be replaced with the indicator id (dash-delimited).
             For example, "https://example.com/[id].html" will be replaced with
             "https://example.com/4-1-1.html".
+        baseurl : string
+            An optional path that all absolute URLs in the data repository start with.
         """
         self.outputs = outputs
         self.folder = folder
         self.branding = branding
         self.intro = intro
         self.indicator_url = indicator_url
+        self.baseurl = baseurl
         self.slugs = []
         self.languages = ['en'] if languages is None else languages
         if translations is not None:
@@ -70,7 +74,7 @@ class OutputDocumentationService:
             pages.append({
                 'title': title,
                 'filename': self.create_filename(title),
-                'content': output.get_documentation_content(self.languages),
+                'content': output.get_documentation_content(self.languages, self.baseurl),
                 'description': output.get_documentation_description()
             })
             extras = output.get_documentation_extras()
@@ -279,7 +283,7 @@ class OutputDocumentationService:
         <body>
             <nav class="navbar navbar-expand-lg navbar-light bg-light">
                 <div class="container">
-                    <a class="navbar-brand" href="index.html">{branding}</a>
+                    <a class="navbar-brand" href="{baseurl}index.html">{branding}</a>
                 </div>
             </nav>
             <main role="main">
@@ -299,7 +303,7 @@ class OutputDocumentationService:
             }});</script>
         </html>
         """
-        return template.format(branding=self.branding, title=title, content=content)
+        return template.format(branding=self.branding, title=title, content=content, baseurl=self.baseurl)
 
 
     def html_from_dataframe(self, df, escape=False, totals=True):

--- a/sdg/open_sdg.py
+++ b/sdg/open_sdg.py
@@ -43,7 +43,7 @@ def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
                    reporting_status_extra_fields=None, config='open_sdg_config.yml',
                    inputs=None, alter_data=None, alter_meta=None, indicator_options=None,
                    docs_branding='Build docs', docs_intro='', docs_indicator_url=None,
-                   docs_subfolder=None, indicator_downloads=None):
+                   docs_subfolder=None, indicator_downloads=None, docs_baseurl=''):
     """Read each input file and edge file and write out json.
 
     Args:
@@ -67,6 +67,7 @@ def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
         docs_intro: string. An introduction for the documentation homepage
         docs_indicator_url: string. A pattern for indicator URLs on the site repo
         docs_subfolder: string. A subfolder in which to put the documentation pages
+        docs_baseurl: string. A baseurl to put at the beginning of all absolute links
         indicator_downloads: list. A list of dicts describing calls to the
             write_downloads() method of IndicatorDownloadService
 
@@ -98,6 +99,7 @@ def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
         'docs_intro': docs_intro,
         'docs_indicator_url': docs_indicator_url,
         'docs_subfolder': docs_subfolder,
+        'docs_baseurl': docs_baseurl,
         'indicator_options': indicator_options,
         'indicator_downloads': indicator_downloads,
     }
@@ -139,6 +141,7 @@ def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
         languages=options['languages'],
         translations=options['translations'],
         indicator_url=options['docs_indicator_url'],
+        baseurl=options['docs_baseurl'],
     )
     documentation_service.generate_documentation()
 

--- a/sdg/open_sdg.py
+++ b/sdg/open_sdg.py
@@ -130,12 +130,9 @@ def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
             status = status & output.execute()
 
     # Output the documentation pages.
-    if options['docs_subfolder'] is not None:
-        docs_folder = os.path.join(options['site_dir'], options['docs_subfolder'])
-    else:
-        docs_folder = options['site_dir']
     documentation_service = sdg.OutputDocumentationService(outputs,
-        folder=docs_folder,
+        folder=options['site_dir'],
+        subfolder=options['docs_subfolder'],
         branding=options['docs_branding'],
         intro=options['docs_intro'],
         languages=options['languages'],

--- a/sdg/outputs/OutputBase.py
+++ b/sdg/outputs/OutputBase.py
@@ -187,7 +187,7 @@ class OutputBase:
         return type(self).__name__
 
 
-    def get_documentation_content(self, languages=None):
+    def get_documentation_content(self, languages=None, baseurl=''):
         """Get detailed content for this output, for documentation purposes.
 
         Parameters

--- a/sdg/outputs/OutputGeoJson.py
+++ b/sdg/outputs/OutputGeoJson.py
@@ -308,7 +308,7 @@ class OutputGeoJson(OutputBase):
         return 'GeoJSON output - ' + self.output_subfolder
 
 
-    def get_documentation_content(self, languages=None):
+    def get_documentation_content(self, languages=None, baseurl=''):
         if languages is None:
             languages = ['']
 
@@ -320,7 +320,7 @@ class OutputGeoJson(OutputBase):
         for language in languages:
             for indicator_id in indicator_ids:
                 path = endpoint.format(language=language, indicator_id=indicator_id, folder=self.output_subfolder)
-                output += '<li><a href="' + path + '">' + path + '</a></li>'
+                output += '<li><a href="' + baseurl + path + '">' + path + '</a></li>'
         output += '<li>etc...</li>'
         output += '</ul>'
 

--- a/sdg/outputs/OutputOpenSdg.py
+++ b/sdg/outputs/OutputOpenSdg.py
@@ -148,7 +148,7 @@ class OutputOpenSdg(OutputBase):
         return 'Open SDG output'
 
 
-    def get_documentation_content(self, languages=None):
+    def get_documentation_content(self, languages=None, baseurl=''):
         if languages is None:
             languages = ['']
 
@@ -241,7 +241,7 @@ class OutputOpenSdg(OutputBase):
                 for indicator_id in indicator_ids:
                     for endpoint in section['endpoints']:
                         path = endpoint.format(language=language, indicator_id=indicator_id)
-                        output += '<li><a href="' + path + '">' + path + '</a></li>'
+                        output += '<li><a href="' + baseurl + path + '">' + path + '</a></li>'
                     if section['loop_indicators'] == False:
                         break
             if section['loop_indicators'] == True:


### PR DESCRIPTION
Fixes #166 
Fixes #162 

This adds optional "baseurl" functionality to the automated output documentation, which fixes an issue with the "subfolder" parameter, and also makes the header "branding" link actually point to the root of the documentation section, regardless of whether the user is in a subfolder.