### PR TITLE
Standalone indicators

### DIFF
--- a/sdg/DisaggregationReportService.py
+++ b/sdg/DisaggregationReportService.py
@@ -102,7 +102,9 @@ class DisaggregationReportService:
         indicators = {}
         for output in self.outputs:
             for indicator_id in output.get_indicator_ids():
-                indicators[indicator_id] = output.get_indicator_by_id(indicator_id)
+                indicator = output.get_indicator_by_id(indicator_id)
+                if not indicator.is_standalone():
+                    indicators[indicator_id] = indicator
         return indicators
 
 

--- a/sdg/DisaggregationStatusService.py
+++ b/sdg/DisaggregationStatusService.py
@@ -54,6 +54,8 @@ class DisaggregationStatusService:
         goals = {}
         for indicator_id in self.indicators:
             indicator = self.indicators[indicator_id]
+            if indicator.is_standalone():
+                continue
             goal = int(indicator.get_goal_id())
             goals[goal] = True
         goal_ids = list(goals.keys())

--- a/sdg/DisaggregationStatusService.py
+++ b/sdg/DisaggregationStatusService.py
@@ -139,6 +139,10 @@ class DisaggregationStatusService:
 
         for indicator_id in self.indicators:
             indicator = self.indicators[indicator_id]
+
+            if indicator.is_standalone():
+                continue
+
             is_notapplicable = self.is_indicator_notapplicable(indicator_id)
             is_complete = self.is_indicator_complete(indicator_id)
             is_inprogress = self.is_indicator_inprogress(indicator_id)

--- a/sdg/Indicator.py
+++ b/sdg/Indicator.py
@@ -161,7 +161,7 @@ class Indicator:
         string
             The number of the goal.
         """
-        return self.inid.split('-')[0]
+        return self.inid if self.is_standalone() else self.inid.split('-')[0]
 
 
     def get_target_id(self):
@@ -172,7 +172,7 @@ class Indicator:
         string
             The target id, dot-delimited.
         """
-        return '.'.join(self.inid.split('-')[0:2])
+        return self.inid if self.is_standalone else '.'.join(self.inid.split('-')[0:2])
 
 
     def get_indicator_id(self):
@@ -183,7 +183,7 @@ class Indicator:
         string
             The indicator id, dot-delimited.
         """
-        return self.inid.replace('-', '.')
+        return self.inid if self.is_standalone() else self.inid.replace('-', '.')
 
 
     def require_meta(self, minimum_metadata=None):

--- a/sdg/Indicator.py
+++ b/sdg/Indicator.py
@@ -328,6 +328,21 @@ class Indicator:
             return self.has_data()
 
 
+    def is_standalone(self):
+        """Decide whether this indicator is standalone - ie, not part of the SDGs.
+
+        Returns
+        -------
+        boolean
+            True if the indicator should be considered standalone, False otherwise.
+        """
+        standalone = self.get_meta_field_value('standalone')
+        if standalone is None or standalone == False:
+            return False
+        else:
+            return True
+
+
     def get_meta_field_value(self, field):
         """Get the value for a metadata field.
 

--- a/sdg/stats.py
+++ b/sdg/stats.py
@@ -33,14 +33,17 @@ def reporting_status(schema, all_meta, extra_fields=None):
                       'translation_key': value_translation[status]}
                     for status in status_values]
 
+    # Omit any standalone indicators.
+    indicators = {k: v for (k, v) in all_meta.items() if 'standalone' not in v or v['standalone'] == False }
+
     # Pick out only the fields we want from each indicators metadata
     fields = ['reporting_status'] + grouping_fields
     rows = [
         {k: meta.get(k) for k in fields}
-        for (key, meta) in all_meta.items()
+        for (key, meta) in indicators.items()
     ]
     # Convert that into a dataframe.
-    meta_df = pd.DataFrame(rows, index=all_meta.keys())
+    meta_df = pd.DataFrame(rows, index=indicators.keys())
     meta_df.fillna('status.not_specified', inplace=True)
 
     # Make sure that numeric columns are numeric.


### PR DESCRIPTION
Allow for indicators to have a metadata field of `standalone` which prevents them from affecting reporting status, disaggregation status, and disaggregation reports.