### PR TITLE
Show raw value in disagg report, then all languages

### DIFF
--- a/docs/examples/open_sdg_config.yml
+++ b/docs/examples/open_sdg_config.yml
@@ -115,6 +115,8 @@ docs_intro: This is a list of examples of endpoints and output that are
   available on this service. Click each of the links below for more information
   on the available output.
 docs_indicator_url: https://my-github-org/my-site-repository/[id]
+# Whether to provide columns for translations in the disaggregation report.
+docs_translate_disaggregations: true
 
 # Indicator downloads
 # -------------------

--- a/sdg/DisaggregationReportService.py
+++ b/sdg/DisaggregationReportService.py
@@ -147,11 +147,12 @@ class DisaggregationReportService:
         )
 
 
-    def translate(self, text, language):
+    def translate(self, text, language, group=None):
         if self.translation_helper is None:
             return text
         else:
-            return self.translation_helper.translate(text, language, 'data')
+            default_group = 'data' if group is None else [group, 'data']
+            return self.translation_helper.translate(text, language, default_group)
 
 
     def get_disaggregations_dataframe(self):
@@ -173,7 +174,7 @@ class DisaggregationReportService:
                 'Number of values': num_values,
             }
             for language in self.get_languages():
-                row[language] = self.translate(disaggregation, language)
+                row[language] = self.translate(disaggregation, language, disaggregation)
             rows.append(row)
 
         columns = ['Disaggregation']
@@ -217,7 +218,7 @@ class DisaggregationReportService:
                 'Number of indicators': len(info['values'][value]['indicators'].keys()),
             }
             for language in self.get_languages():
-                row[language] = self.translate(value, language)
+                row[language] = self.translate(value, language, info['name'])
             rows.append(row)
 
         columns = ['Value']

--- a/sdg/DisaggregationReportService.py
+++ b/sdg/DisaggregationReportService.py
@@ -17,9 +17,9 @@ class DisaggregationReportService:
             Required list of objects inheriting from OutputBase. Each output
             will receive its own documentation page (or pages).
         languages : list
-            Optional list of language codes. If more than one language is
-            provided, any languages beyond the first will display as translations
-            in additional columns. Defaults to ['en'].
+            Optional list of language codes. If languages are provided, these
+            languages will display as translations in additional columns.
+            Defaults to [].
         translation_helper : TranslationHelper
             Instance of TranslationHelper class to perform translations.
         indicator_url : string
@@ -31,7 +31,7 @@ class DisaggregationReportService:
         self.outputs = outputs
         self.indicator_url = indicator_url
         self.slugs = []
-        self.languages = ['en'] if languages is None else languages
+        self.languages = [] if languages is None else languages
         self.translation_helper = translation_helper
         self.disaggregation_store = None
 

--- a/sdg/DisaggregationReportService.py
+++ b/sdg/DisaggregationReportService.py
@@ -136,19 +136,15 @@ class DisaggregationReportService:
     def get_disaggregation_link(self, disaggregation_info):
         return '<a href="{}">{}</a>'.format(
             disaggregation_info['filename'],
-            self.translate(disaggregation_info['name'], self.get_default_language())
+            disaggregation_info['name'],
         )
 
 
     def get_disaggregation_value_link(self, disaggregation_value_info):
         return '<a href="{}">{}</a>'.format(
             disaggregation_value_info['filename'],
-            self.translate(disaggregation_value_info['name'], self.get_default_language())
+            disaggregation_value_info['name'],
         )
-
-
-    def get_default_language(self):
-        return self.languages[0]
 
 
     def translate(self, text, language):
@@ -176,12 +172,12 @@ class DisaggregationReportService:
                 'Number of indicators':  num_indicators,
                 'Number of values': num_values,
             }
-            for language in self.get_additional_languages():
+            for language in self.get_languages():
                 row[language] = self.translate(disaggregation, language)
             rows.append(row)
 
         columns = ['Disaggregation']
-        columns.extend(self.get_additional_languages())
+        columns.extend(self.get_languages())
         columns.extend(['Number of indicators', 'Number of values'])
 
         df = pd.DataFrame(rows, columns=columns)
@@ -190,10 +186,8 @@ class DisaggregationReportService:
         return df
 
 
-    def get_additional_languages(self):
-        if len(self.languages) == 1:
-            return []
-        return self.languages[1:]
+    def get_languages(self):
+        return self.languages
 
 
     def get_indicators_dataframe(self):
@@ -222,12 +216,12 @@ class DisaggregationReportService:
                 'Disaggregation combinations using this value': info['values'][value]['instances'],
                 'Number of indicators': len(info['values'][value]['indicators'].keys()),
             }
-            for language in self.get_additional_languages():
+            for language in self.get_languages():
                 row[language] = self.translate(value, language)
             rows.append(row)
 
         columns = ['Value']
-        columns.extend(self.get_additional_languages())
+        columns.extend(self.get_languages())
         columns.extend(['Disaggregation combinations using this value', 'Number of indicators'])
 
         df = pd.DataFrame(rows, columns=columns)

--- a/sdg/OutputDocumentationService.py
+++ b/sdg/OutputDocumentationService.py
@@ -15,7 +15,7 @@ class OutputDocumentationService:
 
     def __init__(self, outputs, folder='_site', branding='Build docs',
                  languages=None, intro='', translations=None, indicator_url=None,
-                 subfolder=None, baseurl=''):
+                 subfolder=None, baseurl='', translate_disaggregations=False):
         """Constructor for the OutputDocumentationService class.
 
         Parameters
@@ -48,6 +48,9 @@ class OutputDocumentationService:
             "https://example.com/4-1-1.html".
         baseurl : string
             An optional path that all absolute URLs in the data repository start with.
+        translate_disaggregations : boolean
+            Whether or not to include translation columns in the
+            disaggregation report.
         """
         self.outputs = outputs
         self.folder = self.fix_folder(folder, subfolder)
@@ -64,7 +67,7 @@ class OutputDocumentationService:
             self.translation_helper = None
         self.disaggregation_report_service = sdg.DisaggregationReportService(
             self.outputs,
-            languages = self.languages,
+            languages = self.languages if translate_disaggregations else [],
             translation_helper = self.translation_helper,
             indicator_url = self.indicator_url
         )

--- a/sdg/open_sdg.py
+++ b/sdg/open_sdg.py
@@ -43,7 +43,8 @@ def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
                    reporting_status_extra_fields=None, config='open_sdg_config.yml',
                    inputs=None, alter_data=None, alter_meta=None, indicator_options=None,
                    docs_branding='Build docs', docs_intro='', docs_indicator_url=None,
-                   docs_subfolder=None, indicator_downloads=None, docs_baseurl=''):
+                   docs_subfolder=None, indicator_downloads=None, docs_baseurl='',
+                   docs_translate_disaggregations=False):
     """Read each input file and edge file and write out json.
 
     Args:
@@ -70,6 +71,8 @@ def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
         docs_baseurl: string. A baseurl to put at the beginning of all absolute links
         indicator_downloads: list. A list of dicts describing calls to the
             write_downloads() method of IndicatorDownloadService
+        docs_translate_disaggregations: boolean. Whether to provide translated columns
+            in the disaggregation report
 
     Returns:
         Boolean status of file writes
@@ -100,6 +103,7 @@ def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
         'docs_indicator_url': docs_indicator_url,
         'docs_subfolder': docs_subfolder,
         'docs_baseurl': docs_baseurl,
+        'docs_translate_disaggregations': docs_translate_disaggregations,
         'indicator_options': indicator_options,
         'indicator_downloads': indicator_downloads,
     }
@@ -139,6 +143,7 @@ def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
         translations=options['translations'],
         indicator_url=options['docs_indicator_url'],
         baseurl=options['docs_baseurl'],
+        translate_disaggregations=options['docs_translate_disaggregations'],
     )
     documentation_service.generate_documentation()
 


### PR DESCRIPTION
Fixes https://github.com/open-sdg/open-sdg/issues/1020

This makes the translation columns optional. To turn them on, the config setting is:

```
docs_translate_disaggregations: true
```

Feature branch with `docs_translate_disaggregations: true`: http://sdgdev-813006012.eu-west-1.elb.amazonaws.com/data/disagg-report-show-raw-value-true/disaggregations.html

Feature branch without `docs_translate_disaggregations: true`: http://sdgdev-813006012.eu-west-1.elb.amazonaws.com/data/disagg-report-show-raw-value/disaggregations.html