### PR TITLE
Allow for extra columns in disaggregation report

### DIFF
--- a/docs/examples/open_sdg_config.yml
+++ b/docs/examples/open_sdg_config.yml
@@ -115,6 +115,8 @@ docs_intro: This is a list of examples of endpoints and output that are
   available on this service. Click each of the links below for more information
   on the available output.
 docs_indicator_url: https://my-github-org/my-site-repository/[id]
+docs_extra_disaggregations:
+  - Units
 
 # Indicator downloads
 # -------------------

--- a/sdg/DisaggregationReportService.py
+++ b/sdg/DisaggregationReportService.py
@@ -8,7 +8,7 @@ class DisaggregationReportService:
 
 
     def __init__(self, outputs, languages=None, translation_helper=None,
-                 indicator_url=None):
+                 indicator_url=None, extra_disaggregations=None):
         """Constructor for the DisaggregationReportService class.
 
         Parameters
@@ -27,12 +27,17 @@ class DisaggregationReportService:
             the "[id]" will be replaced with the indicator id (dash-delimited).
             For example, "https://example.com/[id].html" will be replaced with
             "https://example.com/4-1-1.html".
+        extra_disaggregations : list
+            Optional list of columns to include, which would not otherwise be
+            included. Common choices are are units of measurement and series,
+            which some users may prefer to see in the report.
         """
         self.outputs = outputs
         self.indicator_url = indicator_url
         self.slugs = []
         self.languages = ['en'] if languages is None else languages
         self.translation_helper = translation_helper
+        self.extra_disaggregations = [] if extra_disaggregations is None else extra_disaggregations
         self.disaggregation_store = None
 
 
@@ -59,6 +64,7 @@ class DisaggregationReportService:
             if not indicators[indicator_id].is_complete():
                 continue
             non_disaggregation_columns = indicators[indicator_id].options.get_non_disaggregation_columns()
+            non_disaggregation_columns = [col for col in non_disaggregation_columns if col not in self.extra_disaggregations]
             for series in indicators[indicator_id].get_all_series():
                 disaggregations = series.get_disaggregations()
                 for disaggregation in disaggregations:

--- a/sdg/OutputDocumentationService.py
+++ b/sdg/OutputDocumentationService.py
@@ -15,7 +15,7 @@ class OutputDocumentationService:
 
     def __init__(self, outputs, folder='_site', branding='Build docs',
                  languages=None, intro='', translations=None, indicator_url=None,
-                 subfolder=None, baseurl='', extra_disaggregatons=None):
+                 subfolder=None, baseurl='', extra_disaggregations=None):
         """Constructor for the OutputDocumentationService class.
 
         Parameters

--- a/sdg/OutputDocumentationService.py
+++ b/sdg/OutputDocumentationService.py
@@ -15,7 +15,7 @@ class OutputDocumentationService:
 
     def __init__(self, outputs, folder='_site', branding='Build docs',
                  languages=None, intro='', translations=None, indicator_url=None,
-                 subfolder=None, baseurl=''):
+                 subfolder=None, baseurl='', extra_disaggregatons=None):
         """Constructor for the OutputDocumentationService class.
 
         Parameters
@@ -48,6 +48,10 @@ class OutputDocumentationService:
             "https://example.com/4-1-1.html".
         baseurl : string
             An optional path that all absolute URLs in the data repository start with.
+        extra_disaggregations : list
+            An optional list of columns to include in the disaggregation report,
+            which would otherwise not be included. Common options are units of
+            measurement and series.
         """
         self.outputs = outputs
         self.folder = self.fix_folder(folder, subfolder)
@@ -66,7 +70,8 @@ class OutputDocumentationService:
             self.outputs,
             languages = self.languages,
             translation_helper = self.translation_helper,
-            indicator_url = self.indicator_url
+            indicator_url = self.indicator_url,
+            extra_disaggregations = extra_disaggregations,
         )
 
 

--- a/sdg/open_sdg.py
+++ b/sdg/open_sdg.py
@@ -43,7 +43,8 @@ def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
                    reporting_status_extra_fields=None, config='open_sdg_config.yml',
                    inputs=None, alter_data=None, alter_meta=None, indicator_options=None,
                    docs_branding='Build docs', docs_intro='', docs_indicator_url=None,
-                   docs_subfolder=None, indicator_downloads=None, docs_baseurl=''):
+                   docs_subfolder=None, indicator_downloads=None, docs_baseurl='',
+                   docs_extra_disaggregations=None):
     """Read each input file and edge file and write out json.
 
     Args:
@@ -70,6 +71,8 @@ def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
         docs_baseurl: string. A baseurl to put at the beginning of all absolute links
         indicator_downloads: list. A list of dicts describing calls to the
             write_downloads() method of IndicatorDownloadService
+        docs_extra_disaggregations: list. An optional list of extra columns
+            that would not otherwise be included in the disaggregation report
 
     Returns:
         Boolean status of file writes
@@ -102,6 +105,7 @@ def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
         'docs_baseurl': docs_baseurl,
         'indicator_options': indicator_options,
         'indicator_downloads': indicator_downloads,
+        'docs_extra_disaggrations': docs_extra_disaggregations,
     }
     # Allow for a config file to update these.
     options = open_sdg_config(config, defaults)
@@ -139,6 +143,7 @@ def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
         translations=options['translations'],
         indicator_url=options['docs_indicator_url'],
         baseurl=options['docs_baseurl'],
+        extra_disaggregations=options['docs_extra_disaggregations'],
     )
     documentation_service.generate_documentation()
 


### PR DESCRIPTION
Some countries may need to see their values for units of measurement and/or series. Normally these are excluded from the disaggregation report, but this PR allows them to be included, by using this config (or similar):

```
docs_extra_disaggregations:
  - UNIT_MEASURE
  - SERIES
```

Feature branch with:
```
docs_extra_disaggregations:
  - Unit measure
  - Units
```
http://sdgdev-813006012.eu-west-1.elb.amazonaws.com/data/disagg-report-include-columns/disaggregations.html