### PR TITLE
Output docs accessibility fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 pyyaml
 pandas
-numpy
 gitpython
 jsonschema
 requests

--- a/sdg/DisaggregationReportService.py
+++ b/sdg/DisaggregationReportService.py
@@ -264,16 +264,16 @@ class DisaggregationReportService:
     def get_disaggregation_report_template(self):
         return """
         <div class="list-group list-group-horizontal mb-4">
-            <a class="list-group-item list-group-item-action" href="#by-disaggregation">By disaggregation</a>
-            <a class="list-group-item list-group-item-action" href="#by-indicator">By indicator</a>
+            <a class="list-group-item list-group-item-action" href="#by-disaggregation">Jump to list of disaggregations</a>
+            <a class="list-group-item list-group-item-action" href="#by-indicator">Jump to list of indicators</a>
         </div>
         <div>
-            <h2 id="by-disaggregation">By disaggregation</h2>
+            <h2 id="by-disaggregation">Disaggregations</h2>
             {disaggregation_download}
             {disaggregation_table}
         </div>
         <div>
-            <h2 id="by-indicator">By indicator</h2>
+            <h2 id="by-indicator">Indicators</h2>
             {indicator_download}
             {indicator_table}
         </div>
@@ -283,16 +283,16 @@ class DisaggregationReportService:
     def get_disaggregation_detail_template(self):
         return """
         <div class="list-group list-group-horizontal mb-4">
-            <a class="list-group-item list-group-item-action" href="#values-used">Values used in disaggregation</a>
-            <a class="list-group-item list-group-item-action" href="#indicators-using">Indicators using disaggregation</a>
+            <a class="list-group-item list-group-item-action" href="#values-used">Jump to list of values used in this disaggregation</a>
+            <a class="list-group-item list-group-item-action" href="#indicators-using">Jump to list of indicators using this disaggregation</a>
         </div>
         <div>
-            <h2 id="values-used">Values used in disaggregation</h2>
+            <h2 id="values-used">Values used in this disaggregation</h2>
             {values_download}
             {values_table}
         </div>
         <div>
-            <h2 id="indicators-using">Indicators using disaggregation</h2>
+            <h2 id="indicators-using">Indicators using this disaggregation</h2>
             {indicators_download}
             {indicators_table}
         </div>

--- a/sdg/DisaggregationReportService.py
+++ b/sdg/DisaggregationReportService.py
@@ -263,17 +263,20 @@ class DisaggregationReportService:
 
     def get_disaggregation_report_template(self):
         return """
-        <div class="list-group list-group-horizontal mb-4">
-            <a class="list-group-item list-group-item-action" href="#by-disaggregation">Jump to list of disaggregations</a>
-            <a class="list-group-item list-group-item-action" href="#by-indicator">Jump to list of indicators</a>
+        <div>
+            <p>Contents:</p>
+            <ul aria-label="Table of contents">
+                <li><a aria-label="Go to list of disaggregations" href="#by-disaggregation">By disaggregation</a></li>
+                <li><a aria-label="Go to list of indicators" href="#by-indicator">By indicator</a></li>
+            </ul>
         </div>
         <div>
-            <h2 id="by-disaggregation">Disaggregations</h2>
+            <h2 id="by-disaggregation">By disaggregation</h2>
             {disaggregation_download}
             {disaggregation_table}
         </div>
         <div>
-            <h2 id="by-indicator">Indicators</h2>
+            <h2 id="by-indicator">By indicator</h2>
             {indicator_download}
             {indicator_table}
         </div>
@@ -282,17 +285,20 @@ class DisaggregationReportService:
 
     def get_disaggregation_detail_template(self):
         return """
-        <div class="list-group list-group-horizontal mb-4">
-            <a class="list-group-item list-group-item-action" href="#values-used">Jump to list of values used in this disaggregation</a>
-            <a class="list-group-item list-group-item-action" href="#indicators-using">Jump to list of indicators using this disaggregation</a>
+        <div>
+            <p>Contents:</p>
+            <ul aria-label="Table of contents">
+                <li><a aria-label="Go to list of values used in disaggregation" href="#values-used">Values used in disaggregation</a></li>
+                <li><a aria-label="Go to list of indicators using disaggregation" href="#indicators-using">Indicators using disaggregation</a></li>
+            </ul>
         </div>
         <div>
-            <h2 id="values-used">Values used in this disaggregation</h2>
+            <h2 id="values-used">Values used in disaggregation</h2>
             {values_download}
             {values_table}
         </div>
         <div>
-            <h2 id="indicators-using">Indicators using this disaggregation</h2>
+            <h2 id="indicators-using">Indicators using disaggregation</h2>
             {indicators_download}
             {indicators_table}
         </div>

--- a/sdg/DisaggregationReportService.py
+++ b/sdg/DisaggregationReportService.py
@@ -263,20 +263,20 @@ class DisaggregationReportService:
 
     def get_disaggregation_report_template(self):
         return """
-        <div>
-            <p>Contents:</p>
-            <ul aria-label="Table of contents">
-                <li><a aria-label="Go to list of disaggregations" href="#by-disaggregation">By disaggregation</a></li>
-                <li><a aria-label="Go to list of indicators" href="#by-indicator">By indicator</a></li>
+        <div role="navigation" aria-describedby="contents-heading">
+            <h2 id="contents-heading">On this page</h2>
+            <ul>
+                <li><a href="#by-disaggregation">By disaggregation</a></li>
+                <li><a href="#by-indicator">By indicator</a></li>
             </ul>
         </div>
         <div>
-            <h2 id="by-disaggregation">By disaggregation</h2>
+            <h2 id="by-disaggregation" tabindex="-1">By disaggregation</h2>
             {disaggregation_download}
             {disaggregation_table}
         </div>
         <div>
-            <h2 id="by-indicator">By indicator</h2>
+            <h2 id="by-indicator" tabindex="-1">By indicator</h2>
             {indicator_download}
             {indicator_table}
         </div>
@@ -285,20 +285,20 @@ class DisaggregationReportService:
 
     def get_disaggregation_detail_template(self):
         return """
-        <div>
-            <p>Contents:</p>
-            <ul aria-label="Table of contents">
-                <li><a aria-label="Go to list of values used in disaggregation" href="#values-used">Values used in disaggregation</a></li>
-                <li><a aria-label="Go to list of indicators using disaggregation" href="#indicators-using">Indicators using disaggregation</a></li>
+        <div role="navigation" aria-describedby="contents-heading">
+            <h2 id="contents-heading">On this page</h2>
+            <ul>
+                <li><a href="#values-used">Values used in disaggregation</a></li>
+                <li><a href="#indicators-using">Indicators using disaggregation</a></li>
             </ul>
         </div>
         <div>
-            <h2 id="values-used">Values used in disaggregation</h2>
+            <h2 id="values-used" tabindex="-1">Values used in disaggregation</h2>
             {values_download}
             {values_table}
         </div>
         <div>
-            <h2 id="indicators-using">Indicators using disaggregation</h2>
+            <h2 id="indicators-using" tabindex="-1">Indicators using disaggregation</h2>
             {indicators_download}
             {indicators_table}
         </div>

--- a/sdg/OutputDocumentationService.py
+++ b/sdg/OutputDocumentationService.py
@@ -204,7 +204,7 @@ class OutputDocumentationService:
             title='Disaggregation report',
             description='These tables show information about all the disaggregations used in the data.',
             destination='disaggregations.html',
-            call_to_action='See report'
+            call_to_action='See disaggregation report'
         )
         card_number += 1
         if card_number % 3 == 0:

--- a/sdg/OutputDocumentationService.py
+++ b/sdg/OutputDocumentationService.py
@@ -191,7 +191,7 @@ class OutputDocumentationService:
                 title=page['title'],
                 description=page['description'],
                 destination=page['filename'],
-                call_to_action='See examples'
+                call_to_action='See examples of ' + page['title']
             )
             card_number += 1
             if card_number % 3 == 0:

--- a/sdg/OutputDocumentationService.py
+++ b/sdg/OutputDocumentationService.py
@@ -347,7 +347,7 @@ class OutputDocumentationService:
 
             <script defer src="https://use.fontawesome.com/releases/v5.15.1/js/all.js"></script>
             <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
-            <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/open-sdg/open-sdg-table@0.1.0/open-sdg-table.min.css">
+            <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/open-sdg/open-sdg-table@0.2.0/open-sdg-table.min.css">
             <style>
                 .btn-primary {{
                     background-color: #1D70B8;

--- a/sdg/OutputDocumentationService.py
+++ b/sdg/OutputDocumentationService.py
@@ -236,13 +236,13 @@ class OutputDocumentationService:
         store = self.disaggregation_report_service.get_disaggregation_store()
 
         disaggregation_df = service.get_disaggregations_dataframe()
-        disaggregation_table = self.html_from_dataframe(disaggregation_df)
+        disaggregation_table = self.html_from_dataframe(disaggregation_df, table_id='disaggregation-table')
         disaggregation_download_label = 'Download CSV of disaggregations'
         disaggregation_download_file = 'disaggregation-report.csv'
         disaggregation_download = self.get_csv_download(disaggregation_df, disaggregation_download_file, label=disaggregation_download_label)
 
         indicator_df = service.get_indicators_dataframe()
-        indicator_table = self.html_from_dataframe(indicator_df)
+        indicator_table = self.html_from_dataframe(indicator_df, table_id='indicator-table')
         indicator_download_label = 'Download CSV of indicators'
         indicator_download_file = 'disaggregation-by-indicator-report.csv'
         indicator_download = self.get_csv_download(indicator_df, indicator_download_file, label=indicator_download_label)
@@ -270,13 +270,13 @@ class OutputDocumentationService:
         values_download_label = 'Download CSV of values used in this disaggregation'
         values_download_file = 'values--' + filename.replace('.html', '.csv')
         values_download = self.get_csv_download(values_df, values_download_file, label=values_download_label)
-        values_table = self.html_from_dataframe(values_df)
+        values_table = self.html_from_dataframe(values_df, table_id='values-table')
 
         indicators_df = service.get_disaggregation_indicator_dataframe(info)
         indicators_download_label = 'Download CSV of indicators using this disaggregation'
         indicators_download_file = 'indicators--' + filename.replace('.html', '.csv')
         indicators_download = self.get_csv_download(indicators_df, indicators_download_file, label=indicators_download_label)
-        indicators_table = self.html_from_dataframe(indicators_df)
+        indicators_table = self.html_from_dataframe(indicators_df, table_id='indicators-table')
 
         detail_html = self.get_html('Disaggregation: ' + disaggregation, service.get_disaggregation_detail_template().format(
             values_download=values_download,
@@ -297,7 +297,7 @@ class OutputDocumentationService:
         download_label = 'Download CSV of indicators using this disaggregation value'
         download_file = filename.replace('.html', '.csv')
         download = self.get_csv_download(df, download_file, label=download_label)
-        table = self.html_from_dataframe(df)
+        table = self.html_from_dataframe(df, table_id='disaggregation-value-table')
 
         html = self.get_html(disaggregation + ': ' + disaggregation_value, service.get_disaggregation_value_detail_template().format(
             download=download,
@@ -345,9 +345,9 @@ class OutputDocumentationService:
 
             <title>{title} - {branding}</title>
 
-            <script defer src="https://use.fontawesome.com/releases/v5.0.2/js/all.js"></script>
+            <script defer src="https://use.fontawesome.com/releases/v5.15.1/js/all.js"></script>
             <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
-            <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/frankieroberto/sortable-table@master/src/sortable-table.css" />
+            <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/open-sdg/open-sdg-table@0.1.0/open-sdg-table.min.css">
             <style>
                 .btn-primary {{
                     background-color: #1D70B8;
@@ -376,34 +376,38 @@ class OutputDocumentationService:
                     </div>
                 </div>
             </div>
-            <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
+            <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+            <script src="https://cdn.datatables.net/1.10.23/js/jquery.dataTables.min.js"></script>
+            <script src="https://cdn.jsdelivr.net/gh/open-sdg/open-sdg-table@0.1.0/open-sdg-table.min.js"></script>
             <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
             <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
-            <script src="https://cdn.jsdelivr.net/gh/frankieroberto/sortable-table@master/src/sortable-table.js"></script>
             <script>
-
-            $(".tablesorter").each(function() {{
-                $(this).find('th').attr('aria-sort', 'none');
-                $(this).find('td').each(function() {{
-                    if (!isNaN($(this).text())) {{
-                        $(this).css('text-align', 'right');
-                    }}
-                }});
-                new SortableTable(this);
-            }});
+            if (typeof sdgBuild !== 'undefined' && sdgBuild.tables) {{
+                var tableIds = Object.keys(sdgBuild.tables);
+                for (var i = 0; i < tableIds.length; i++) {{
+                    var tableId = tableIds[i];
+                    $('#' + tableId).openSdgTable(sdgBuild.tables[tableId]).find('td').each(function() {{
+                        if (!isNaN($(this).text())) {{
+                            $(this).css('text-align', 'right');
+                        }}
+                    }})
+                }}
+            }}
             </script>
         </html>
         """
         return template.format(branding=self.branding, title=title, content=content, baseurl=self.docs_baseurl)
 
 
-    def html_from_dataframe(self, df, escape=False, totals=True):
+    def html_from_dataframe(self, df, table_id='docs-table', escape=False, total=True):
         """Generate an HTML table from a DataFrame.
 
         Paramters
         ---------
         df : DataFrame
             The dataframe itself.
+        table_id : string
+            An identifier for the table, which should be unique on this web page.
         escape : boolean
             Whether or not to escape content. If the cells need to contain
             HTML, this should be False. Defaults to False.
@@ -412,14 +416,25 @@ class OutputDocumentationService:
             Defaults to True.
         """
         html = ''
-        if totals:
-            html = """
+        if total:
+            html += """
                 <div class="total-rows">
                     Total rows: <span class="total">{}</span>
                 </div>
                 """.format(len(df))
-        html += df.to_html(escape=escape, index=False, classes="table table-striped table-bordered tablesorter")
+        html += df.to_html(escape=escape, index=False, classes='table table-striped table-bordered', table_id=table_id)
+        html += self.javascript_from_dataframe(df, table_id)
         return html
+
+
+    def javascript_from_dataframe(self, df, table_id):
+        return """
+            <script type="text/javascript">
+            var sdgBuild = sdgBuild || {{}};
+            sdgBuild.tables = sdgBuild.tables || {{}};
+            sdgBuild.tables['{}'] = {};
+            </script>
+            """.format(table_id, df.to_json(orient='records'))
 
 
     def write_page(self, filename, html):

--- a/sdg/OutputDocumentationService.py
+++ b/sdg/OutputDocumentationService.py
@@ -319,7 +319,7 @@ class OutputDocumentationService:
             <meta http-equiv="X-UA-Compatible" content="IE=edge">
             <meta name="viewport" content="width=device-width, initial-scale=1">
 
-            <title>{branding} - {title}</title>
+            <title>{title} - {branding}</title>
 
             <script defer src="https://use.fontawesome.com/releases/v5.0.2/js/all.js"></script>
             <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">

--- a/sdg/OutputDocumentationService.py
+++ b/sdg/OutputDocumentationService.py
@@ -347,7 +347,7 @@ class OutputDocumentationService:
 
             <script defer src="https://use.fontawesome.com/releases/v5.0.2/js/all.js"></script>
             <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
-            <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.31.3/css/theme.bootstrap_4.min.css" integrity="sha256-vFn0MM8utz2N3JoNzRxHXUtfCJLz5Pb9ygBY2exIaqg=" crossorigin="anonymous" />
+            <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/frankieroberto/sortable-table@master/src/sortable-table.css" />
             <style>
                 .btn-primary {{
                     background-color: #1D70B8;
@@ -379,11 +379,18 @@ class OutputDocumentationService:
             <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
             <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
             <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.31.3/js/jquery.tablesorter.min.js" integrity="sha256-dtGH1XcAyKopMui5x20KnPxuGuSx9Rs6piJB/4Oqu6I=" crossorigin="anonymous"></script>
+            <script src="https://cdn.jsdelivr.net/gh/frankieroberto/sortable-table@master/src/sortable-table.js"></script>
             <script>
-            $(".tablesorter").tablesorter({{
-                theme: 'bootstrap'
-            }}).removeAttr('role');
+
+            $(".tablesorter").each(function() {{
+                $(this).find('th').attr('aria-sort', 'none');
+                $(this).find('td').each(function() {{
+                    if (!isNaN($(this).text())) {{
+                        $(this).css('text-align', 'right');
+                    }}
+                }});
+                new SortableTable(this);
+            }});
             </script>
         </html>
         """

--- a/sdg/OutputDocumentationService.py
+++ b/sdg/OutputDocumentationService.py
@@ -347,7 +347,7 @@ class OutputDocumentationService:
 
             <script defer src="https://use.fontawesome.com/releases/v5.15.1/js/all.js"></script>
             <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
-            <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/open-sdg/open-sdg-table@0.3.0/open-sdg-table.min.css">
+            <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/open-sdg/open-sdg-table@0.4.0/open-sdg-table.min.css">
             <style>
                 .btn-primary {{
                     background-color: #1D70B8;
@@ -378,7 +378,7 @@ class OutputDocumentationService:
             </div>
             <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
             <script src="https://cdn.datatables.net/1.10.23/js/jquery.dataTables.min.js"></script>
-            <script src="https://cdn.jsdelivr.net/gh/open-sdg/open-sdg-table@0.3.0/open-sdg-table.min.js"></script>
+            <script src="https://cdn.jsdelivr.net/gh/open-sdg/open-sdg-table@0.4.0/open-sdg-table.min.js"></script>
             <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
             <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
             <script>

--- a/sdg/OutputDocumentationService.py
+++ b/sdg/OutputDocumentationService.py
@@ -347,7 +347,7 @@ class OutputDocumentationService:
 
             <script defer src="https://use.fontawesome.com/releases/v5.15.1/js/all.js"></script>
             <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
-            <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/open-sdg/open-sdg-table@0.2.0/open-sdg-table.min.css">
+            <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/open-sdg/open-sdg-table@0.3.0/open-sdg-table.min.css">
             <style>
                 .btn-primary {{
                     background-color: #1D70B8;
@@ -378,7 +378,7 @@ class OutputDocumentationService:
             </div>
             <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
             <script src="https://cdn.datatables.net/1.10.23/js/jquery.dataTables.min.js"></script>
-            <script src="https://cdn.jsdelivr.net/gh/open-sdg/open-sdg-table@0.2.0/open-sdg-table.min.js"></script>
+            <script src="https://cdn.jsdelivr.net/gh/open-sdg/open-sdg-table@0.3.0/open-sdg-table.min.js"></script>
             <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
             <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
             <script>

--- a/sdg/OutputDocumentationService.py
+++ b/sdg/OutputDocumentationService.py
@@ -378,7 +378,7 @@ class OutputDocumentationService:
             </div>
             <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
             <script src="https://cdn.datatables.net/1.10.23/js/jquery.dataTables.min.js"></script>
-            <script src="https://cdn.jsdelivr.net/gh/open-sdg/open-sdg-table@0.1.0/open-sdg-table.min.js"></script>
+            <script src="https://cdn.jsdelivr.net/gh/open-sdg/open-sdg-table@0.2.0/open-sdg-table.min.js"></script>
             <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
             <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
             <script>


### PR DESCRIPTION
Fixes https://github.com/open-sdg/open-sdg/issues/1033

This PR includes these changes:

1. More descriptive labels for the Download CSV links
2. Removes 'role="grid"' in the tables. There is mention in the feedback of using similar markup to the tables in Open SDG. The tables in Open SDG are built in a pretty complex way and have been tweaked heavily for accessibility. Because these tables are built in a different way, it would take a bit of work to mimic the Open SDG tables. It can be done though if necessary. For now I've just done the specific change mentioned in the feedback: removing the role attribute.
3. More descriptive jump links at the top
4. Change order of the page titles: page title first and then branding
5. File size for CSV downloads
6. Add role=button to CSV downloads

Feature branch: http://sdgdev-813006012.eu-west-1.elb.amazonaws.com/data/output-docs-accessibility-fixes-take-2/disaggregations.html
