### PR TITLE
Allow the export filename to be configured

### DIFF
--- a/docs/examples/open_sdg_config.yml
+++ b/docs/examples/open_sdg_config.yml
@@ -132,3 +132,10 @@ indicator_downloads:
     output_folder: data-csv
     # The "indicator_id_pattern" is optional, default below:
     indicator_id_pattern: indicator_(.*)
+
+# Indicator export (zip file)
+# ---------------------------
+# This controls the filename of the zipped file of indicator data.
+# The file extension (.zip) is not needed. The defualt, if omitted,
+# is below:
+indicator_export_filename: all_indicators

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 pyyaml
 pandas
-numpy
 gitpython
 jsonschema
 requests

--- a/sdg/IndicatorExportService.py
+++ b/sdg/IndicatorExportService.py
@@ -5,7 +5,7 @@ from zipfile import ZipFile
 import humanize
 
 class IndicatorExportService:
-    def __init__(self, site_directory, indicators):
+    def __init__(self, site_directory, indicators, filename='all_indicators'):
         """Constructor for IndicatorExportService.
 
         Parameters
@@ -20,11 +20,12 @@ class IndicatorExportService:
         self.__zip_directory = "%s/zip" % site_directory
         self.__data_directory = "%s/data" % site_directory
         self.__indicators = indicators
+        self.__filename = filename
 
     def export_all_indicator_data_as_zip_archive(self):
         self.__create_zip_folder_at_site_directory()
         csv_files = self.__get_all_indicator_csv_files()
-        self.__create_zip_file("all_indicators.zip", csv_files)
+        self.__create_zip_file(self.__filename + ".zip", csv_files)
 
     def __create_zip_folder_at_site_directory(self):
         directory = "%s/zip" % self.__site_directory

--- a/sdg/IndicatorExportService.py
+++ b/sdg/IndicatorExportService.py
@@ -73,7 +73,7 @@ class IndicatorExportService:
 
     def __save_zip_file_info(self, zip_file_name):
         info = self.__get_zip_file_info(zip_file_name)
-        json_file_name = zip_file_name.replace('.zip', '.json')
+        json_file_name = 'all_indicators.json'
         with open(os.path.join(self.__zip_directory, json_file_name), 'w') as f:
             json.dump(info, f)
 
@@ -81,7 +81,8 @@ class IndicatorExportService:
         size = self.__get_zip_file_size(zip_file_name)
         info = {
             'size_bytes': size,
-            'size_human': humanize.naturalsize(size)
+            'size_human': humanize.naturalsize(size),
+            'filename': self.__filename + '.zip'
         }
         repo = self.__get_git_repository()
         if repo is not None:

--- a/sdg/open_sdg.py
+++ b/sdg/open_sdg.py
@@ -213,6 +213,7 @@ def open_sdg_check(src_dir='', schema_file='_prose.yml', config='open_sdg_config
         'translations': [],
         'indicator_options': indicator_options,
         'indicator_downloads': None,
+        'indicator_export_filename': None,
     }
     # Allow for a config file to update these.
     options = open_sdg_config(config, defaults)

--- a/sdg/open_sdg.py
+++ b/sdg/open_sdg.py
@@ -44,7 +44,8 @@ def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
                    inputs=None, alter_data=None, alter_meta=None, indicator_options=None,
                    docs_branding='Build docs', docs_intro='', docs_indicator_url=None,
                    docs_subfolder=None, indicator_downloads=None, docs_baseurl='',
-                   docs_extra_disaggregations=None, docs_translate_disaggregations=False):
+                   docs_extra_disaggregations=None, docs_translate_disaggregations=False,
+                   indicator_export_filename='all_indicators'):
     """Read each input file and edge file and write out json.
 
     Args:
@@ -75,6 +76,7 @@ def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
             that would not otherwise be included in the disaggregation report
         docs_translate_disaggregations: boolean. Whether to provide translated columns
             in the disaggregation report
+        indicator_export_filename: string. Filename without extension for zip file
 
     Returns:
         Boolean status of file writes
@@ -109,6 +111,7 @@ def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
         'indicator_options': indicator_options,
         'indicator_downloads': indicator_downloads,
         'docs_extra_disaggregations': docs_extra_disaggregations,
+        'indicator_export_filename': indicator_export_filename,
     }
     # Allow for a config file to update these.
     options = open_sdg_config(config, defaults)
@@ -276,7 +279,8 @@ def open_sdg_prep(options):
         translations=options['translations'],
         reporting_status_extra_fields=reporting_status_extra_fields,
         indicator_options=options['indicator_options'],
-        indicator_downloads=options['indicator_downloads'])
+        indicator_downloads=options['indicator_downloads'],
+        indicator_export_filename=options['indicator_export_filename'])
 
     outputs = [opensdg_output]
 

--- a/sdg/outputs/OutputOpenSdg.py
+++ b/sdg/outputs/OutputOpenSdg.py
@@ -10,7 +10,7 @@ class OutputOpenSdg(OutputBase):
 
     def __init__(self, inputs, schema, output_folder='_site', translations=None,
         reporting_status_extra_fields=None, indicator_options=None,
-        indicator_downloads=None):
+        indicator_downloads=None, indicator_export_filename='all_indicators'):
         """Constructor for OutputOpenSdg.
 
         Parameters
@@ -23,6 +23,8 @@ class OutputOpenSdg(OutputBase):
         indicator_downloads : list
             A list of dicts describing calls to the write_downloads() method of
             IndicatorDownloadService.
+        indicator_export_filename : string
+            A filename (without the extension) for the zipped indicator export.
         """
         if translations is None:
             translations = []
@@ -30,6 +32,7 @@ class OutputOpenSdg(OutputBase):
         OutputBase.__init__(self, inputs, schema, output_folder, translations, indicator_options)
         self.reporting_status_grouping_fields = reporting_status_extra_fields
         self.indicator_downloads = indicator_downloads
+        self.indicator_export_filename = indicator_export_filename
 
 
     def build(self, language=None):
@@ -88,7 +91,7 @@ class OutputOpenSdg(OutputBase):
         disaggregation_status_service = sdg.DisaggregationStatusService(site_dir, self.indicators, self.reporting_status_grouping_fields)
         disaggregation_status_service.write_json()
 
-        indicator_export_service = sdg.IndicatorExportService(site_dir, self.indicators)
+        indicator_export_service = sdg.IndicatorExportService(site_dir, self.indicators, self.indicator_export_filename)
         indicator_export_service.export_all_indicator_data_as_zip_archive()
 
         # Write the indicator downloads.

--- a/sdg/outputs/OutputOpenSdg.py
+++ b/sdg/outputs/OutputOpenSdg.py
@@ -209,7 +209,7 @@ class OutputOpenSdg(OutputBase):
                 'description': 'Zip files containing all indicators in CSV form',
                 'loop_indicators': False,
                 'endpoints': [
-                    '{language}/zip/all_indicators.zip'
+                    '{language}/zip/' + self.indicator_export_filename + '.zip'
                 ]
             },
             {

--- a/sdg/outputs/OutputOpenSdg.py
+++ b/sdg/outputs/OutputOpenSdg.py
@@ -91,7 +91,7 @@ class OutputOpenSdg(OutputBase):
         disaggregation_status_service = sdg.DisaggregationStatusService(site_dir, self.indicators, self.reporting_status_grouping_fields)
         disaggregation_status_service.write_json()
 
-        indicator_export_service = sdg.IndicatorExportService(site_dir, self.indicators, self.indicator_export_filename)
+        indicator_export_service = sdg.IndicatorExportService(site_dir, self.indicators, filename=self.indicator_export_filename)
         indicator_export_service.export_all_indicator_data_as_zip_archive()
 
         # Write the indicator downloads.


### PR DESCRIPTION
Fixes #679

The data config setting to test here is: `indicator_export_filename`, and should be the desired filename without the extension. For example:

`indicator_export_filename: uk_sdg_indicators`