### PR TITLE
Allow numeric disaggregaton

### DIFF
--- a/sdg/DisaggregationReportService.py
+++ b/sdg/DisaggregationReportService.py
@@ -121,7 +121,7 @@ class DisaggregationReportService:
         string
             The title converted into a unique *.html filename
         """
-        slug = prefix + slugify(title)
+        slug = prefix + slugify(str(title))
         if slug in self.slugs:
             slug = slug + '_'
         if len(slug) > 100:

--- a/sdg/OutputDocumentationService.py
+++ b/sdg/OutputDocumentationService.py
@@ -298,8 +298,8 @@ class OutputDocumentationService:
 
     def write_disaggregation_value_detail_page(self, info):
         service = self.disaggregation_report_service
-        disaggregation = info['disaggregation']
-        disaggregation_value = info['name']
+        disaggregation = str(info['disaggregation'])
+        disaggregation_value = str(info['name'])
         filename = info['filename']
 
         df = service.get_disaggregation_value_dataframe(info)

--- a/sdg/inputs/InputBase.py
+++ b/sdg/inputs/InputBase.py
@@ -61,6 +61,8 @@ class InputBase:
         cols = df.columns.tolist()
         cols.pop(cols.index('Year'))
         cols.pop(cols.index('Value'))
+        for col in cols:
+            df[col] = df[col].map(str)
         cols = ['Year'] + cols + ['Value']
         return df[cols]
 
@@ -77,7 +79,7 @@ class InputBase:
         Dataframe
             The same dataframe with rearranged columns
         """
-        return df.replace([None, ""], np.NaN)
+        return df.replace([None, "", "nan"], np.NaN)
 
 
     def fetch_file(self, location):


### PR DESCRIPTION
Fixes https://github.com/open-sdg/open-sdg/issues/327

This does two things:
1. Prevent Python exceptions when a disaggregation column contains numeric values
2. Ensure the data output treats disaggregation columns as strings, even if they are numeric

## Testing

To help with testing I created a pull-request on the Open SDG project to see what happens when a disaggregation is numeric: https://github.com/open-sdg/open-sdg/pull/1072

You can see that the first automated test succeeded, because it was pointing at this `brockfanning/sdg-build-1@allow-numeric-disaggregation` branch. Then I reverted and pointed back at the `open-sdg/sdg-build@1.3.0-dev` branch, and as expected the tests failed.

Manual tests are still a good idea, because this is a potentially impactful change. But hopefully this "failure demonstration" provides some extra assurance that this fixes the problem.