### PR TITLE
Allow dimension query in UN API input

### DIFF
--- a/sdg/inputs/InputSdmx.py
+++ b/sdg/inputs/InputSdmx.py
@@ -370,7 +370,10 @@ class InputSdmx(InputBase):
 
         InputBase.execute(self, indicator_options)
         # Fetch the response from the SDMX endpoint.
-        self.fetch_data()
+        try:
+            self.fetch_data()
+        except:
+            raise Exception('SDMX source could not be fetched: ' + self.source)
 
         # SDMX divides the data into series, but we want to divide
         # the data into indicators. Indicators contain multiple series,

--- a/sdg/inputs/InputSdmxMl_UnitedNationsApi.py
+++ b/sdg/inputs/InputSdmxMl_UnitedNationsApi.py
@@ -53,7 +53,7 @@ class InputSdmxMl_UnitedNationsApi(InputSdmxMl_Structure):
 
         prefix = 'https://data.un.org/ws/rest/data/IAEG-SDGs,DF_SDG_GLH,1.3/'
         suffix = '/ALL/?detail=full&dimensionAtObservation=TIME_PERIOD'
-        values = map(lambda x: self.dimension_query[x] if x in self.dimension_query else '', params)
+        values = map(lambda x: str(self.dimension_query[x]) if x in self.dimension_query else '', params)
         query = '.'.join(values)
 
         return prefix + query + suffix

--- a/sdg/inputs/InputSdmxMl_UnitedNationsApi.py
+++ b/sdg/inputs/InputSdmxMl_UnitedNationsApi.py
@@ -3,21 +3,57 @@ from sdg.inputs import InputSdmxMl_Structure
 class InputSdmxMl_UnitedNationsApi(InputSdmxMl_Structure):
     """SDG data specifically called from the UN SDGs-SDMX API."""
 
-    def __init__(self, reference_area='1', **kwargs):
+    def __init__(self, reference_area='1', dimension_query=None, **kwargs):
         """ Constructor for InputSdmxMultiple.
 
         Parameters
         ----------
         reference_area : string
             The SDMX in the REF_AREA dimension. Defaults to '1' (world).
+        dimension_query : dict
+            A dict of SDMX dimensions to use in generating the query. For details see:
+            https://unstats.un.org/sdgs/files/SDMX_SDG_API_MANUAL.pdf
         kwargs
             All the other keyword parameters to be passed to the InputSdmxMl_Structure class.
         """
         self.reference_area = reference_area
+        if dimension_query is None:
+            dimension_query = {}
+        self.dimension_query = dimension_query
         if 'source' not in kwargs:
-            kwargs['source'] = 'https://data.un.org/ws/rest/data/IAEG-SDGs,DF_SDG_GLH,1.3/...' + str(reference_area) + '.........../ALL/?detail=full&dimensionAtObservation=TIME_PERIOD'
+            kwargs['source'] = self.get_api_query()
         if 'dsd' not in kwargs:
             kwargs['dsd'] = 'https://registry.sdmx.org/ws/public/sdmxapi/rest/datastructure/IAEG-SDGs/SDG/latest/?format=sdmx-2.1&detail=full&references=children'
         if 'drop_dimensions' not in kwargs:
             kwargs['drop_dimensions'] = ['DATA_LAST_UPDATE', 'TIME_DETAIL']
         InputSdmxMl_Structure.__init__(self, **kwargs)
+
+
+    def get_api_query(self):
+        params = [
+            'FREQ',
+            'REPORTING_TYPE',
+            'SERIES',
+            'REF_AREA',
+            'SEX',
+            'AGE',
+            'URBANISATION',
+            'INCOME_WEALTH_QUANTILE',
+            'EDUCATION_LEV',
+            'OCCUPATION',
+            'CUST_BREAKDOWN',
+            'COMPOSITE_BREAKDOWN',
+            'DISABILITY_STATUS',
+            'ACTIVITY',
+            'PRODUCT',
+        ]
+        dimension_query = self.dimension_query
+        if 'REF_AREA' not in dimension_query and self.reference_area is not None:
+            dimension_query['REF_AREA'] = str(self.reference_area)
+
+        prefix = 'https://data.un.org/ws/rest/data/IAEG-SDGs,DF_SDG_GLH,1.3/'
+        suffix = '/ALL/?detail=full&dimensionAtObservation=TIME_PERIOD'
+        values = map(lambda x: self.dimension_query[x] if x in self.dimension_query else '', params)
+        query = '.'.join(values)
+
+        return prefix + query + suffix


### PR DESCRIPTION
This allows a dimension query to be passed in to the UN API input, for more fine-grained control over the query. To show an example, the following are identical:

The original "reference_area" approach:

```
inputs:
  - class: InputSdmxMl_UnitedNationsApi
    reference_area: 524
```

And here's the new approach which would be identical:

```
inputs:
  - class: InputSdmxMl_UnitedNationsApi
    dimension_query:
      REF_AREA: 524
```

Other examples, here's how to limit to national reporting:

```
inputs:
  - class: InputSdmxMl_UnitedNationsApi
    dimension_query:
      REF_AREA: 524
      REPORTING_TYPE: N
```

Or to pull multiple reference areas (eg, Nepal and India) using the "+" syntax:

```
inputs:
  - class: InputSdmxMl_UnitedNationsApi
    dimension_query:
      REF_AREA: 524+356
```

More details on the query construction is here: https://unstats.un.org/sdgs/files/SDMX_SDG_API_MANUAL.pdf