### PR TITLE
Don't cast 'None' to a string

### DIFF
--- a/sdg/inputs/InputBase.py
+++ b/sdg/inputs/InputBase.py
@@ -78,7 +78,7 @@ class InputBase(Loggable):
         cols.pop(cols.index('Year'))
         cols.pop(cols.index('Value'))
         for col in cols:
-            df[col] = df[col].map(str)
+            df[col] = df[col].map(str, na_action='ignore')
         cols = ['Year'] + cols + ['Value']
         return df[cols]
 


### PR DESCRIPTION
[This recent change](https://github.com/open-sdg/sdg-build/pull/198) is causing Python's `None` to be converted into the string "None". I've noticed this in the case of an SDMX input (trying out Rwanda's data against 1.3.0-dev branches).