### PR TITLE
Allow schema_file parameter to work

### DIFF
--- a/sdg/open_sdg.py
+++ b/sdg/open_sdg.py
@@ -89,8 +89,6 @@ def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
         inputs = open_sdg_input_defaults()
     if translations is None:
         translations = open_sdg_translation_defaults()
-    if schema is None:
-        schema = open_sdg_schema_defaults(schema_file)
     if indicator_options is None:
         indicator_options = open_sdg_indicator_options_defaults()
     if logging is None:
@@ -123,6 +121,9 @@ def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
     }
     # Allow for a config file to update these.
     options = open_sdg_config(config, defaults)
+
+    if options['schema'] is None:
+        options['schema'] = open_sdg_schema_defaults(options['schema_file'])
 
     # Convert the translations and schemas.
     options['translations'] = open_sdg_translations_from_options(options)
@@ -216,8 +217,6 @@ def open_sdg_check(src_dir='', schema_file='_prose.yml', config='open_sdg_config
     """
     if inputs is None:
         inputs = open_sdg_input_defaults()
-    if schema is None:
-        schema = open_sdg_schema_defaults(schema_file)
     if indicator_options is None:
         indicator_options = open_sdg_indicator_options_defaults()
 
@@ -237,6 +236,9 @@ def open_sdg_check(src_dir='', schema_file='_prose.yml', config='open_sdg_config
     }
     # Allow for a config file to update these.
     options = open_sdg_config(config, defaults)
+
+    if options['schema'] is None:
+        options['schema'] = open_sdg_schema_defaults(options['schema_file'])
 
     # Convert the translations.
     options['translations'] = open_sdg_translations_from_options(options)


### PR DESCRIPTION
This fixes a regression bug in 1.3.0-dev, which is preventing the "schema_file" config option from working. This bug probably was not obvious because in most cases with Open SDG the schema_file is set to the default, which is "_prose.yml". But the schema_file config option is supposed to be able to specify a different file name. For example, we're supposed to be able to rename it to "foo.yml" and then set `schema_file: foo.yml` in the data config. This PR is to restore that functionality, which got broken by a recent PR.