### PR TITLE
Allow data for a single indicator to come from multiple inputs

### DIFF
--- a/sdg/Indicator.py
+++ b/sdg/Indicator.py
@@ -105,6 +105,7 @@ class Indicator(Loggable):
 
         if self.has_data():
             self.data = pd.concat([self.data, val], sort=False)
+            self.enforce_column_order()
         else:
             self.data = val
         self.set_headline()
@@ -215,10 +216,18 @@ class Indicator(Loggable):
         """Ensure at least an empty dataset for this indicator."""
         if self.data is None:
             df = pd.DataFrame({'Year':[], 'Value':[]})
-            # Enforce the order of columns.
-            cols = ['Year', 'Value']
-            df = df[cols]
             self.data = df
+            self.enforce_column_order()
+
+
+    def enforce_column_order(self):
+        if self.has_data():
+            df = self.data
+            cols = df.columns.tolist()
+            cols.pop(cols.index('Year'))
+            cols.pop(cols.index('Value'))
+            cols = ['Year'] + cols + ['Value']
+            self.data = df[cols]
 
 
     def language(self, language=None):

--- a/sdg/Indicator.py
+++ b/sdg/Indicator.py
@@ -103,7 +103,10 @@ class Indicator(Loggable):
         if val is None or not isinstance(val, pd.DataFrame) or val.empty:
             return
 
-        self.data = val
+        if self.has_data():
+            self.data = pd.concat([self.data, val], sort=False)
+        else:
+            self.data = val
         self.set_headline()
         self.set_edges()
 


### PR DESCRIPTION
This is a low-priority feature without a clear user requirement, but I wanted to post this in case it's interesting. I think the main use-case for this would be something like:

* The main data input is difficult to edit and lacks some disaggregation (such as data from a third-party web service or something like that)
* The developer would like to have a local CSV file with additional data rows to add the necessary disaggregation
* So the developer adds a CSV input, expecting the CSV data to be "concatenated" onto the other data

Since it's a minor code change I thought it would be worth posting. This would definitely need testing though, in case it has any unforeseen consequences.