### PR TITLE
Always set all dimensions in SDMX output

### DIFF
--- a/sdg/outputs/OutputSdmxMl.py
+++ b/sdg/outputs/OutputSdmxMl.py
@@ -168,9 +168,11 @@ class OutputSdmxMl(OutputBase):
             # Skip the TIME_PERIOD dimension because it is used as the "observation dimension".
             if dimension.id == 'TIME_PERIOD':
                 continue
-            value = row[dimension.id] if dimension.id in row else self.get_dimension_default(dimension.id, indicator)
-            if value != '':
-                values[dimension.id] = value
+            if dimension.id in row and row[dimension.id] != '':
+                value = row[dimension.id]
+            else:
+                value = self.get_dimension_default(dimension.id, indicator)
+            values[dimension.id] = str(value)
         return values
 
 


### PR DESCRIPTION
In SDMX all of the dimensions are required for each series. So the output here should always set each dimension, regardless of whether there is a value or not. If not, it should always use the default value.