### PR TITLE
SDMX output: StructureSpecific

### DIFF
--- a/sdg/open_sdg.py
+++ b/sdg/open_sdg.py
@@ -335,6 +335,7 @@ def open_sdg_prep(options):
             output_folder=options['site_dir'],
             translations=options['translations'],
             indicator_options=options['indicator_options'],
+            structure_specific=True,
             **options['sdmx_output']
         ))
 

--- a/sdg/open_sdg.py
+++ b/sdg/open_sdg.py
@@ -329,13 +329,14 @@ def open_sdg_prep(options):
 
     # Add SDMX output if configured.
     if 'sdmx_output' in options and 'dsd' in options['sdmx_output']:
+        if 'structure_specific' not in options['sdmx_output']:
+            options['sdmx_output'] = True
         outputs.append(sdg.outputs.OutputSdmxMl(
             inputs=inputs,
             schema=schema,
             output_folder=options['site_dir'],
             translations=options['translations'],
             indicator_options=options['indicator_options'],
-            structure_specific=True,
             **options['sdmx_output']
         ))
 

--- a/sdg/outputs/OutputSdmxMl.py
+++ b/sdg/outputs/OutputSdmxMl.py
@@ -10,7 +10,7 @@ from sdmx.model import (
     Key,
     AttributeValue,
     Observation,
-    GenericTimeSeriesDataSet,
+    StructureSpecificTimeSeriesDataSet,
     DataflowDefinition,
     Agency
 )
@@ -124,7 +124,7 @@ class OutputSdmxMl(OutputBase):
                     serieses[series_key] = []
                 serieses[series_key].append(observation)
 
-            dataset = GenericTimeSeriesDataSet(structured_by=self.dsd, series=serieses)
+            dataset = StructureSpecificTimeSeriesDataSet(structured_by=self.dsd, series=serieses)
             header = self.create_header()
             time_period = next(dim for dim in self.dsd.dimensions if dim.id == 'TIME_PERIOD')
             msg = DataMessage(data=[dataset], dataflow=dfd, header=header, observation_dimension=time_period)

--- a/sdg/outputs/OutputSdmxMl.py
+++ b/sdg/outputs/OutputSdmxMl.py
@@ -71,7 +71,6 @@ class OutputSdmxMl(OutputBase):
         self.sender_id = sender_id
         self.structure_specific = structure_specific
         self.retrieve_dsd(dsd)
-        self.concept_map = concept_map
         sdmx_folder = os.path.join(output_folder, 'sdmx')
         if not os.path.exists(sdmx_folder):
             os.makedirs(sdmx_folder, exist_ok=True)
@@ -101,16 +100,6 @@ class OutputSdmxMl(OutputBase):
         for indicator_id in self.get_indicator_ids():
             indicator = self.get_indicator_by_id(indicator_id).language(language)
             data = indicator.data.copy()
-            
-            if self.concept_map is not None:
-                concept_map=pd.read_csv(self.concept_map)
-                for col in data.columns:
-                    if col in concept_map['CSV_colname'].to_list():
-                            for i in data.index:
-                                if data.at[i, col] in concept_map['CSV_cellvalue'].to_list():
-                                    data.at[i, col]=concept_map['SDMX_codelist_item'].loc[concept_map['CSV_colname']==col].loc[concept_map['CSV_cellvalue']==data.at[i, col]].iloc[0]
-                            newcol=concept_map['SDMX_concept'].loc[concept_map['CSV_colname']==col].iloc[0]
-                            data.rename(columns={col:newcol}, inplace=True)
 
             # Some hardcoded dataframe changes.
             data = data.rename(columns={

--- a/sdg/outputs/OutputSdmxMl.py
+++ b/sdg/outputs/OutputSdmxMl.py
@@ -10,6 +10,7 @@ from sdmx.model import (
     Key,
     AttributeValue,
     Observation,
+    GenericTimeSeriesDataSet,
     StructureSpecificTimeSeriesDataSet,
     DataflowDefinition,
     Agency
@@ -27,7 +28,7 @@ class OutputSdmxMl(OutputBase):
 
     def __init__(self, inputs, schema, output_folder='_site', translations=None,
                  indicator_options=None, dsd='https://registry.sdmx.org/ws/public/sdmxapi/rest/datastructure/IAEG-SDGs/SDG/latest/?format=sdmx-2.1&detail=full&references=children',
-                 default_values=None, header_id=None, sender_id=None):
+                 default_values=None, header_id=None, sender_id=None, structure_specific=False):
         """Constructor for OutputSdmxMl.
 
         This output assumes the following:
@@ -59,10 +60,13 @@ class OutputSdmxMl(OutputBase):
             Optional identifying string to put in the "id" attribut of the "Sender" element
             in the header of the XML. If not specified, it will be the current version
             of this library.
+        structure_specific : boolean
+            Whether to output as StructureSpecific instead of Generic data.
         """
         OutputBase.__init__(self, inputs, schema, output_folder, translations, indicator_options)
         self.header_id = header_id
         self.sender_id = sender_id
+        self.structure_specific = structure_specific
         self.retrieve_dsd(dsd)
         sdmx_folder = os.path.join(output_folder, 'sdmx')
         if not os.path.exists(sdmx_folder):
@@ -124,7 +128,7 @@ class OutputSdmxMl(OutputBase):
                     serieses[series_key] = []
                 serieses[series_key].append(observation)
 
-            dataset = StructureSpecificTimeSeriesDataSet(structured_by=self.dsd, series=serieses)
+            dataset = self.create_dataset(serieses)
             header = self.create_header()
             time_period = next(dim for dim in self.dsd.dimensions if dim.id == 'TIME_PERIOD')
             msg = DataMessage(data=[dataset], dataflow=dfd, header=header, observation_dimension=time_period)
@@ -160,6 +164,11 @@ class OutputSdmxMl(OutputBase):
             prepared=time.strftime('%Y-%m-%dT%H:%M:%S', time.gmtime(timestamp)),
             sender=Agency(id=sender_id),
         )
+
+
+    def create_dataset(self, serieses):
+        dataset_class = StructureSpecificTimeSeriesDataSet if self.structure_specific else GenericTimeSeriesDataSet
+        return dataset_class(structured_by=self.dsd, series=serieses)
 
 
     def get_dimension_values(self, row, indicator):


### PR DESCRIPTION
Fixes #205 

With version 2.3.0 of the sdmx library, we can now produce StructureSpecific output. This PR makes this the default for Open SDG output, and also makes it an optional parameter.