### PR TITLE
Fixes for SDMX single-file output

### DIFF
--- a/sdg/outputs/OutputSdmxMl.py
+++ b/sdg/outputs/OutputSdmxMl.py
@@ -141,7 +141,7 @@ class OutputSdmxMl(OutputBase):
             all_serieses.update(serieses)
 
         dataset = self.create_dataset(all_serieses)
-        msg = DataMessage(data=dataset, dataflow=dfd, header=header, observation_dimension=time_period)
+        msg = DataMessage(data=[dataset], dataflow=dfd, header=header, observation_dimension=time_period)
         all_sdmx_path = os.path.join(self.sdmx_folder, 'all.xml')
         with open(all_sdmx_path, 'wb') as f:
             status = status & f.write(sdmx.to_xml(msg))

--- a/sdg/outputs/OutputSdmxMl.py
+++ b/sdg/outputs/OutputSdmxMl.py
@@ -90,7 +90,7 @@ class OutputSdmxMl(OutputBase):
     def build(self, language=None):
         """Write the SDMX output. Overrides parent."""
         status = True
-        all_serieses = []
+        all_serieses = {}
         dfd = DataflowDefinition(id="OPEN_SDG_DFD", structure=self.dsd)
         time_period = next(dim for dim in self.dsd.dimensions if dim.id == 'TIME_PERIOD')
         header = self.create_header()
@@ -138,7 +138,7 @@ class OutputSdmxMl(OutputBase):
             sdmx_path = os.path.join(self.sdmx_folder, indicator_id + '.xml')
             with open(sdmx_path, 'wb') as f:
                 status = status & f.write(sdmx.to_xml(msg))
-            all_serieses = all_serieses + serieses
+            all_serieses.update(serieses)
 
         dataset = self.create_dataset(all_serieses)
         msg = DataMessage(data=dataset, dataflow=dfd, header=header, observation_dimension=time_period)

--- a/sdg/outputs/OutputSdmxMl.py
+++ b/sdg/outputs/OutputSdmxMl.py
@@ -92,6 +92,8 @@ class OutputSdmxMl(OutputBase):
         status = True
         datasets = []
         dfd = DataflowDefinition(id="OPEN_SDG_DFD", structure=self.dsd)
+        time_period = next(dim for dim in self.dsd.dimensions if dim.id == 'TIME_PERIOD')
+        header = self.create_header()
 
         # SDMX output is language-agnostic. Only the DSD contains language info.
         if language is not None:
@@ -132,15 +134,13 @@ class OutputSdmxMl(OutputBase):
                 serieses[series_key].append(observation)
 
             dataset = self.create_dataset(serieses)
-            header = self.create_header()
-            time_period = next(dim for dim in self.dsd.dimensions if dim.id == 'TIME_PERIOD')
             msg = DataMessage(data=[dataset], dataflow=dfd, header=header, observation_dimension=time_period)
             sdmx_path = os.path.join(self.sdmx_folder, indicator_id + '.xml')
             with open(sdmx_path, 'wb') as f:
                 status = status & f.write(sdmx.to_xml(msg))
             datasets.append(dataset)
 
-        msg = DataMessage(data=datasets, dataflow=dfd)
+        msg = DataMessage(data=datasets, dataflow=dfd, header=header, observation_dimension=time_period)
         all_sdmx_path = os.path.join(self.sdmx_folder, 'all.xml')
         with open(all_sdmx_path, 'wb') as f:
             status = status & f.write(sdmx.to_xml(msg))

--- a/sdg/outputs/OutputSdmxMl.py
+++ b/sdg/outputs/OutputSdmxMl.py
@@ -90,7 +90,7 @@ class OutputSdmxMl(OutputBase):
     def build(self, language=None):
         """Write the SDMX output. Overrides parent."""
         status = True
-        datasets = []
+        all_serieses = []
         dfd = DataflowDefinition(id="OPEN_SDG_DFD", structure=self.dsd)
         time_period = next(dim for dim in self.dsd.dimensions if dim.id == 'TIME_PERIOD')
         header = self.create_header()
@@ -138,9 +138,10 @@ class OutputSdmxMl(OutputBase):
             sdmx_path = os.path.join(self.sdmx_folder, indicator_id + '.xml')
             with open(sdmx_path, 'wb') as f:
                 status = status & f.write(sdmx.to_xml(msg))
-            datasets.append(dataset)
+            all_serieses = all_serieses + serieses
 
-        msg = DataMessage(data=datasets, dataflow=dfd, header=header, observation_dimension=time_period)
+        dataset = self.create_dataset(all_serieses)
+        msg = DataMessage(data=dataset, dataflow=dfd, header=header, observation_dimension=time_period)
         all_sdmx_path = os.path.join(self.sdmx_folder, 'all.xml')
         with open(all_sdmx_path, 'wb') as f:
             status = status & f.write(sdmx.to_xml(msg))


### PR DESCRIPTION
Fixes #229 

This uses the same "header" and "observation_dimension" parameters for the "all.xml" output as for the single-indicator output. Hopefully this helps the compatibility with the SDG Lab.

I've confirmed that this allows the file to be uploaded to the SDG Lab.

However, it only uploads the first (of many) datasets. So I've also made a change here that puts all the series into the same single dataset. I've also confirmed that this resolves the issue with SDG Lab.