### PR TITLE
Expanded input alterations

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ SDG Build can **output** SDG data in the following formats:
 
 Sometimes you may need to alter each indicator's data/metadata/id/name before importing into this library. This can be done after instantiating the input objects, with `add_data_alteration`, `add_meta_alteration`, `add_indicator_id_alteration`, and `add_indicator_name_alteration`. Each of these takes a callback function as a parameter.
 
-In these callback functions, the thing to be altered is passed as the first parameter, followed by the an optional "context" dict, containing the other three items. These
+In these callback functions, the thing to be altered is passed as the first parameter, followed by an optional "context" dict, containing the other three items. These
 "context" dicts contain:
 
 * data : Pandas Dataframe (or None)
@@ -80,6 +80,10 @@ The order of the alterations may be important to know. They can't all be simulta
 4. Metadata
 
 The reason this may be important is, for example, when the indicator name is being altered, the data has not be altered yet; but when the metadata is being altered, the data *has* been altered.
+
+### Note about multiple inputs
+
+In some cases, you may use multiple inputs at the same time, such as YAML files for metadata and CSV files for data. **Note that the `context` parameter described above is limited to each individual input.** For example, if a particular input contains no metadata, then `context['meta']` will be `None` during the alteration of that input. And similarly, if a particular input contains no data, then `context['data']` will be `None` during the alteration of that input. This is important to keep in mind, as you may be expecting that the `context` parameter will have a combination of all inputs.
 
 ## Schemas
 

--- a/README.md
+++ b/README.md
@@ -29,22 +29,54 @@ SDG Build can **output** SDG data in the following formats:
 * GeoJSON for mapping (there is not a global standard for SDG GeoJSON at this time, so this is our best guess at a useful structure)
 * SDMX-ML output
 
-## Alterations of data and metadata
+## Alterations of data, metadata, indicator ID, and indicator name
 
-Sometimes you may need to alter data and/or metadata before importing into this library. This can be done after instantiating the input objects, with `add_data_alteration` and `add_meta_alteration`. For example:
+Sometimes you may need to alter each indicator's data/metadata/id/name before importing into this library. This can be done after instantiating the input objects, with `add_data_alteration`, `add_meta_alteration`, `add_indicator_id_alteration`, and
+`add_indicator_name_alteration`.
+
+In these functions, all four of the following parameters are passed:
+
+* data : Pandas Dataframe (or None)
+* meta : dict (or None)
+* indicator_id : string
+* indicator_name : string (or None)
+
+Here are some examples of using these:
 
 ```
-def my_data_alteration(df):
-    # Drop an unnecessary column in the data.
-    df = df.drop('unnecessary_column', axis='columns')
-    return df
-def my_meta_alteration(meta):
-    # Drop an unecessary field in the metadata.
-    del meta['unnecessary_field']
-    return meta
-my_data_input.add_data_alteration(my_data_alteration)
-my_meta_input.add_meta_alteration(my_meta_alteration)
+def my_indicator_id_alteration(indicator_id, indicator_name=None, data=None, meta=None):
+  # Maybe we need to remove a particular string from the ids.
+  return indicator_id.replace('foo', '')
+
+def my_indicator_name_alteration(indicator_name, indicator_id=None, data=None, meta=None):
+  # Maybe we need to use a particular metadata field for the name.
+  return meta['my_name_field']
+
+def my_data_alteration(data, indicator_name=None, indicator_id=None, meta=None):
+  # Maybe we need to drop an unnecessary column in the data.
+  return df.drop('unnecessary_column', axis='columns')
+
+def my_meta_alteration(meta, indicator_name=None, indicator_id=None, data=None):
+  # Maybe we need to drop an unnecessary field in the metadata.
+  del meta['unnecessary_field']
+  return meta
+
+my_input.add_indicator_id_alteration(my_indicator_id_alteration)
+my_input.add_indicator_name_alteration(my_indicator_name_alteration)
+my_input.add_data_alteration(my_data_alteration)
+my_input.add_meta_alteration(my_meta_alteration)
 ```
+
+### Order of alterations
+
+The order of the alterations may be important to know. They can't all be simultaneous, so here is the order they will happen in:
+
+1. Indicator ID
+2. Indicator name
+3. Data
+4. Metadata
+
+The reason this may be important is, for example, when the indicator name is being altered, the data has not be altered yet; but when the metadata is being altered, the data *has* been altered.
 
 ## Schemas
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ SDG Build can **output** SDG data in the following formats:
 
 ## Alterations of data, metadata, indicator ID, and indicator name
 
-Sometimes you may need to alter each indicator's data/metadata/id/name before importing into this library. This can be done after instantiating the input objects, with `add_data_alteration`, `add_meta_alteration`, `add_indicator_id_alteration`, and
-`add_indicator_name_alteration`.
+Sometimes you may need to alter each indicator's data/metadata/id/name before importing into this library. This can be done after instantiating the input objects, with `add_data_alteration`, `add_meta_alteration`, `add_indicator_id_alteration`, and `add_indicator_name_alteration`. Each of these takes a callback function as a parameter.
 
-In these functions, all four of the following parameters are passed:
+In these callback functions, the thing to be altered is passed as the first parameter, followed by the an optional "context" dict, containing the other three items. These
+"context" dicts contain:
 
 * data : Pandas Dataframe (or None)
 * meta : dict (or None)
@@ -44,21 +44,24 @@ In these functions, all four of the following parameters are passed:
 Here are some examples of using these:
 
 ```
-def my_indicator_id_alteration(indicator_id, indicator_name=None, data=None, meta=None):
-  # Maybe we need to remove a particular string from the ids.
-  return indicator_id.replace('foo', '')
+def my_indicator_id_alteration(indicator_id, context):
+  # Control a particular indicator id by checking the name.
+  if context['indicator_name'] == 'My particular indicator name':
+    return 'my-particular-indicator-id'
+  else:
+    return indicator_id
 
-def my_indicator_name_alteration(indicator_name, indicator_id=None, data=None, meta=None):
+def my_indicator_name_alteration(indicator_name, context):
   # Maybe we need to use a particular metadata field for the name.
-  return meta['my_name_field']
+  return context['meta']['my_name_field']
 
-def my_data_alteration(data, indicator_name=None, indicator_id=None, meta=None):
+def my_data_alteration(data, context):
   # Maybe we need to drop an unnecessary column in the data.
   return df.drop('unnecessary_column', axis='columns')
 
-def my_meta_alteration(meta, indicator_name=None, indicator_id=None, data=None):
-  # Maybe we need to drop an unnecessary field in the metadata.
-  del meta['unnecessary_field']
+def my_meta_alteration(meta, context):
+  # Maybe we need to set the indicator ID as a particular field.
+  meta['my_id_field'] = context['indicator_id']
   return meta
 
 my_input.add_indicator_id_alteration(my_indicator_id_alteration)

--- a/sdg/inputs/InputBase.py
+++ b/sdg/inputs/InputBase.py
@@ -208,8 +208,8 @@ class InputBase(Loggable):
             The indicator options
         """
         # Perform alterations in this order: id, name, data, meta
-        indicator_id = self.normalize_indicator_id(indicator_id, indicator_name=name, data=data, meta=meta)
-        name = self.normalize_indicator_name(name, indicator_id, data=data, meta=meta)
+        indicator_id = self.alter_indicator_id(indicator_id, indicator_name=name, data=data, meta=meta)
+        name = self.alter_indicator_name(name, indicator_id, data=data, meta=meta)
         data = self.alter_data(data, indicator_id=indicator_id, indicator_name=name, meta=meta)
         meta = self.alter_meta(meta, indicator_id=indicator_id, indicator_name=name, data=data)
         indicator = Indicator(indicator_id, name=name, data=data, meta=meta, options=options, logging=self.logging)
@@ -251,6 +251,38 @@ class InputBase(Loggable):
         for alteration in self.meta_alterations:
             meta = alteration(meta=meta, indicator_id=indicator_id, indicator_name=indicator_name, data=data)
         return meta
+
+
+    def alter_indicator_id(self, indicator_id, indicator_name=None, data=None, meta=None):
+        """Alter an indicator id (1-1-1, 1-2-1, etc).
+
+        Parameters
+        ----------
+        indicator_id : string
+            The raw indicator ID
+        """
+        # Perform any alterations on the indicator id.
+        if len(self.indicator_id_alterations) > 0:
+            for alteration in self.indicator_id_alterations:
+                indicator_id = alteration(indicator_id=indicator_id, indicator_name=indicator_name, data=data, meta=meta)
+        return indicator_id
+
+
+    def alter_indicator_name(self, indicator_name, indicator_id, data=None, meta=None):
+        """Alter an indicator name.
+
+        Parameters
+        ----------
+        indicator_name : string
+            The raw indicator name
+        indicator_id : string
+            The indicator id (eg, 1.1.1, 1-1-1, etc.) for this indicator
+        """
+        # Perform any alterations on the indicator id.
+        if len(self.indicator_name_alterations) > 0:
+            for alteration in self.indicator_name_alterations:
+                indicator_name = alteration(indicator_name=indicator_name, indicator_id=indicator_id, data=data, meta=meta)
+        return indicator_name
 
 
     def add_data_alteration(self, alteration):

--- a/sdg/inputs/InputBase.py
+++ b/sdg/inputs/InputBase.py
@@ -120,7 +120,7 @@ class InputBase(Loggable):
         return data
 
 
-    def normalize_indicator_id(self, indicator_id, indicator_name=None, data=None, meta=None):
+    def normalize_indicator_id(self, indicator_id):
         """Normalize an indicator id (1-1-1, 1-2-1, etc).
 
         Parameters
@@ -128,12 +128,6 @@ class InputBase(Loggable):
         indicator_id : string
             The raw indicator ID
         """
-        # Perform any alterations on the indicator id.
-        if len(self.indicator_id_alterations) > 0:
-            for alteration in self.indicator_id_alterations:
-                indicator_id = alteration(indicator_id=indicator_id, indicator_name=indicator_name, data=data, meta=meta)
-            return indicator_id
-        # Otherwise fallback to a general best-effort approach.
         # If there are multiple words, assume the first word is the id.
         words = indicator_id.split(" ")
         indicator_id = words[0]
@@ -144,7 +138,7 @@ class InputBase(Loggable):
         return indicator_id
 
 
-    def normalize_indicator_name(self, indicator_name, indicator_id, data=None, meta=None):
+    def normalize_indicator_name(self, indicator_name, indicator_id):
         """Normalize an indicator name.
 
         Parameters
@@ -154,12 +148,6 @@ class InputBase(Loggable):
         indicator_id : string
             The indicator id (eg, 1.1.1, 1-1-1, etc.) for this indicator
         """
-        # Perform any alterations on the indicator id.
-        if len(self.indicator_name_alterations) > 0:
-            for alteration in self.indicator_name_alterations:
-                indicator_name = alteration(indicator_name=indicator_name, indicator_id=indicator_id, data=data, meta=meta)
-            return indicator_name
-        # Otherwise fallback to a general best-effort approach.
         # Sometimes the indicator names includes the indicator id, so
         # remove it here. Both dash or dot-delimited.
         dashes = indicator_id.replace('.', '-')

--- a/sdg/inputs/InputBase.py
+++ b/sdg/inputs/InputBase.py
@@ -289,6 +289,8 @@ class InputBase(Loggable):
                 except:
                     # Handle callbacks without the context parameter.
                     indicator_id = alteration(indicator_id)
+        # Always make sure that dots are replaced with dashes.
+        indicator_id = indicator_id.replace('.', '-')
         return indicator_id
 
 

--- a/sdg/inputs/InputBase.py
+++ b/sdg/inputs/InputBase.py
@@ -228,7 +228,15 @@ class InputBase(Loggable):
             return data
         # Perform any alterations on the data.
         for alteration in self.data_alterations:
-            data = alteration(data=data, indicator_id=indicator_id, indicator_name=indicator_name, meta=meta)
+            try:
+                data = alteration(data, {
+                    'indicator_id': indicator_id,
+                    'indicator_name': indicator_name,
+                    'meta': meta
+                })
+            except:
+                # Handle callbacks without the context parameter.
+                data = alteration(data)
         # Always do these hardcoded steps.
         data = self.fix_dataframe_columns(data)
         data = self.fix_empty_values(data)
@@ -249,7 +257,15 @@ class InputBase(Loggable):
             else:
                 return meta
         for alteration in self.meta_alterations:
-            meta = alteration(meta=meta, indicator_id=indicator_id, indicator_name=indicator_name, data=data)
+            try:
+                meta = alteration(meta, {
+                    'indicator_id': indicator_id,
+                    'indicator_name': indicator_name,
+                    'data': data
+                })
+            except:
+                # Handle callbacks without the context parameter.
+                meta = alteration(meta)
         return meta
 
 
@@ -264,7 +280,15 @@ class InputBase(Loggable):
         # Perform any alterations on the indicator id.
         if len(self.indicator_id_alterations) > 0:
             for alteration in self.indicator_id_alterations:
-                indicator_id = alteration(indicator_id=indicator_id, indicator_name=indicator_name, data=data, meta=meta)
+                try:
+                    indicator_id = alteration(indicator_id, {
+                        'indicator_name': indicator_name,
+                        'data': data,
+                        'meta': meta
+                    })
+                except:
+                    # Handle callbacks without the context parameter.
+                    indicator_id = alteration(indicator_id)
         return indicator_id
 
 
@@ -281,7 +305,15 @@ class InputBase(Loggable):
         # Perform any alterations on the indicator id.
         if len(self.indicator_name_alterations) > 0:
             for alteration in self.indicator_name_alterations:
-                indicator_name = alteration(indicator_name=indicator_name, indicator_id=indicator_id, data=data, meta=meta)
+                try:
+                    indicator_name = alteration(indicator_name, {
+                        'indicator_id': indicator_id,
+                        'data': data,
+                        'meta': meta
+                    })
+                except:
+                    # Handle callbacks without the context parameter.
+                    indicator_name = alteration(indicator_name)
         return indicator_name
 
 

--- a/sdg/inputs/InputBase.py
+++ b/sdg/inputs/InputBase.py
@@ -225,6 +225,8 @@ class InputBase(Loggable):
             except:
                 # Handle callbacks without the context parameter.
                 data = alteration(data)
+        if data is None:
+            raise Exception('Data alteration functions should return the altered dataframe.')
         # Always do these hardcoded steps.
         data = self.fix_dataframe_columns(data)
         data = self.fix_empty_values(data)
@@ -254,6 +256,8 @@ class InputBase(Loggable):
             except:
                 # Handle callbacks without the context parameter.
                 meta = alteration(meta)
+        if meta is None:
+            raise Exception('Metadata alteration functions should return the altered dict.')
         return meta
 
 

--- a/sdg/inputs/InputSdmx.py
+++ b/sdg/inputs/InputSdmx.py
@@ -225,6 +225,8 @@ class InputSdmx(InputBase):
                 # If indicator_ids are not hardcoded, try to get them from the DSD.
                 indicator_ids = code.findall(self.indicator_id_xpath)
                 indicator_ids = [element.text for element in indicator_ids]
+            # Normalize the indicator ids.
+            indicator_ids = [self.normalize_indicator_id(inid) for inid in indicator_ids]
             # Now get the indicator names from the DSD.
             indicator_names = code.findall(self.indicator_name_xpath)
             # Before going further, make sure there is an indicator name for
@@ -243,7 +245,7 @@ class InputSdmx(InputBase):
             for index, element in enumerate(indicator_names):
 
                 indicator_id = indicator_ids[index]
-                indicator_name = element.text
+                indicator_name = self.normalize_indicator_name(element.text, indicator_id)
                 code_map[indicator_id] = indicator_name
             series_to_indicators[code_id] = code_map
         # Cache it for later.

--- a/sdg/inputs/InputSdmx.py
+++ b/sdg/inputs/InputSdmx.py
@@ -225,8 +225,6 @@ class InputSdmx(InputBase):
                 # If indicator_ids are not hardcoded, try to get them from the DSD.
                 indicator_ids = code.findall(self.indicator_id_xpath)
                 indicator_ids = [element.text for element in indicator_ids]
-            # Normalize the indicator ids.
-            indicator_ids = [self.normalize_indicator_id(inid) for inid in indicator_ids]
             # Now get the indicator names from the DSD.
             indicator_names = code.findall(self.indicator_name_xpath)
             # Before going further, make sure there is an indicator name for
@@ -245,7 +243,7 @@ class InputSdmx(InputBase):
             for index, element in enumerate(indicator_names):
 
                 indicator_id = indicator_ids[index]
-                indicator_name = self.normalize_indicator_name(element.text, indicator_id)
+                indicator_name = element.text
                 code_map[indicator_id] = indicator_name
             series_to_indicators[code_id] = code_map
         # Cache it for later.

--- a/sdg/open_sdg.py
+++ b/sdg/open_sdg.py
@@ -45,7 +45,8 @@ def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
                    docs_branding='Build docs', docs_intro='', docs_indicator_url=None,
                    docs_subfolder=None, indicator_downloads=None, docs_baseurl='',
                    docs_extra_disaggregations=None, docs_translate_disaggregations=False,
-                   logging=None, indicator_export_filename='all_indicators'):
+                   logging=None, indicator_export_filename='all_indicators',
+                   alter_indicator_id=None, alter_indicator_name=None):
     """Read each input file and edge file and write out json.
 
     Args:
@@ -65,6 +66,8 @@ def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
         inputs: list. A list of dicts describing instances of InputBase
         alter_data: function. A callback function that alters a data Dataframe
         alter_meta: function. A callback function that alters a metadata dictionary
+        alter_indicator_id: function. A callback function that alters the indicator id
+        alter_indicator_name: function. A callback function that alters the indicator name
         indicator_options: Dict. Options to pass into each indicator.
         docs_branding: string. A heading for all documentation pages
         docs_intro: string. An introduction for the documentation homepage
@@ -129,9 +132,11 @@ def open_sdg_build(src_dir='', site_dir='_site', schema_file='_prose.yml',
     options['translations'] = open_sdg_translations_from_options(options)
     options['schema'] = open_sdg_schema_from_options(options)
 
-    # Pass along our data/meta alterations.
+    # Pass along our data/meta/id/name alterations.
     options['alter_data'] = alter_data
     options['alter_meta'] = alter_meta
+    options['alter_indicator_id'] = alter_indicator_id
+    options['alter_indicator_name'] = alter_indicator_name
 
     # Convert the indicator options.
     options['indicator_options'] = open_sdg_indicator_options_from_dict(options['indicator_options'])
@@ -195,7 +200,7 @@ def open_sdg_indicator_options_from_dict(options):
 
 def open_sdg_check(src_dir='', schema_file='_prose.yml', config='open_sdg_config.yml',
         inputs=None, alter_data=None, alter_meta=None, indicator_options=None,
-        schema=None, logging=None):
+        schema=None, logging=None, alter_indicator_id=None, alter_indicator_name=None):
     """Run validation checks for all indicators.
 
     This checks both *.csv (data) and *.md (metadata) files.
@@ -210,6 +215,8 @@ def open_sdg_check(src_dir='', schema_file='_prose.yml', config='open_sdg_config
         config: str. Path to a YAML config file that overrides other parameters
         alter_data: function. A callback function that alters a data Dataframe
         alter_meta: function. A callback function that alters a metadata dictionary
+        alter_indicator_id: function. A callback function that alters the indicator id
+        alter_indicator_name: function. A callback function that alters the indicator name
         logging: Noneor list. Type of logs to print, including 'warn' and 'debug'
 
     Returns:
@@ -244,9 +251,11 @@ def open_sdg_check(src_dir='', schema_file='_prose.yml', config='open_sdg_config
     options['translations'] = open_sdg_translations_from_options(options)
     options['schema'] = open_sdg_schema_from_options(options)
 
-    # Pass along our data/meta alterations.
+    # Pass along our data/meta/id/name alterations.
     options['alter_data'] = alter_data
     options['alter_meta'] = alter_meta
+    options['alter_indicator_id'] = alter_indicator_id
+    options['alter_indicator_name'] = alter_indicator_name
 
     # Convert the indicator options.
     options['indicator_options'] = open_sdg_indicator_options_from_dict(options['indicator_options'])
@@ -278,13 +287,19 @@ def open_sdg_prep(options):
     # Combine the inputs into one list.
     inputs = [open_sdg_input_from_dict(input_dict, options) for input_dict in options['inputs']]
 
-    # Do any data/metadata alterations.
+    # Do any data/metadata/id/name alterations.
     if callable(options['alter_data']):
         for input in inputs:
             input.add_data_alteration(options['alter_data'])
     if callable(options['alter_meta']):
         for input in inputs:
             input.add_meta_alteration(options['alter_meta'])
+    if callable(options['alter_indicator_id']):
+        for input in inputs:
+            input.add_indicator_id_alteration(options['alter_indicator_id'])
+    if callable(options['alter_indicator_name']):
+        for input in inputs:
+            input.add_indicator_name_alteration(options['alter_indicator_name'])
 
     # Use the specified metadata schema.
     schema = options['schema']


### PR DESCRIPTION
This includes the following changes:

1. The indicator ID can be altered with a function, just like data and metadata
2. The indicator name can be altered with a function, just like data and metadata
3. All alter functions will be passed an optional "context" dict that contains the indicator_id, indicator_name, data, meta

Existing data/meta alter functions should still work. Examples and more details are in the updated README in this PR.

## Testing note

In particular I would be interested in testing the indicator ID alteration, to make sure it doesn't cause any issues. The other stuff is important to test also though.