### PR TITLE
SDMX and file helper functions

### DIFF
--- a/sdg/__init__.py
+++ b/sdg/__init__.py
@@ -15,6 +15,7 @@ from . import inputs
 from . import outputs
 from . import schemas
 from . import translations
+from . import helpers
 from .DisaggregationReportService import DisaggregationReportService
 from .DisaggregationStatusService import DisaggregationStatusService
 from .OutputDocumentationService import OutputDocumentationService

--- a/sdg/helpers/__init__.py
+++ b/sdg/helpers/__init__.py
@@ -1,0 +1,4 @@
+"""Helper modules for sdg-build"""
+
+from . import files
+from . import sdmx

--- a/sdg/helpers/files.py
+++ b/sdg/helpers/files.py
@@ -1,0 +1,25 @@
+from urllib.request import urlopen, Request
+from shutil import copyfileobj
+
+
+def fetch_remote_file(url, request_params=None):
+    if request_params is None:
+        request_params = {}
+    return urlopen(Request(url, **request_params))
+
+
+def download_remote_file(url, destination, request_params=None):
+    downloaded_file = fetch_remote_file(url, request_params=request_params)
+    with open(destination, 'wb') as out_file:
+        copyfileobj(downloaded_file, out_file)
+
+
+def read_file(location, request_params=None):
+    if location.startswith('http'):
+        file = fetch_remote_file(location, request_params=request_params)
+        data = file.read().decode('utf-8')
+    else:
+        file = open(location)
+        data = file.read()
+    file.close()
+    return data

--- a/sdg/helpers/sdmx.py
+++ b/sdg/helpers/sdmx.py
@@ -1,0 +1,150 @@
+from sdg.helpers import files
+import sdmx
+import os
+from xml.etree import ElementTree as ET
+from io import StringIO
+
+cache = {}
+
+def get_dsd_url():
+    """Returns the remote URL to the global SDMX DSD for the SDGs."""
+    return 'https://registry.sdmx.org/ws/public/sdmxapi/rest/datastructure/IAEG-SDGs/SDG/latest/?format=sdmx-2.1&detail=full&references=children'
+
+
+def get_dsd(path=None, request_params=None):
+    if path is None:
+        path = get_dsd_url()
+    if path in cache and 'get_dsd' in cache[path]:
+        return cache[path]['get_dsd']
+    if path.startswith('http'):
+        filename = 'SDG_DSD.xml'
+        files.download_remote_file(path, filename)
+        msg = sdmx.read_sdmx(filename)
+        os.remove(filename)
+    else:
+        msg = sdmx.read_sdmx(path)
+    dsd_object = msg.structure[0]
+    if path not in cache:
+        cache[path] = {}
+    cache[path]['get_dsd'] = dsd_object
+    return dsd_object
+
+
+def parse_xml(path=None, request_params=None):
+    if path is None:
+        path = get_dsd_url()
+    if path in cache and 'parse_xml' in cache[path]:
+        return cache[path]['parse_xml']
+
+    xml = files.read_file(path, request_params=request_params)
+    it = ET.iterparse(StringIO(xml))
+    for _, el in it:
+        if '}' in el.tag:
+            el.tag = el.tag.split('}', 1)[1]
+        # Strip namespaces from attributes too.
+        for at in list(el.attrib.keys()):
+            if '}' in at:
+                newat = at.split('}', 1)[1]
+                el.attrib[newat] = el.attrib[at]
+                del el.attrib[at]
+    if path not in cache:
+        cache[path] = {}
+    cache[path]['parse_xml'] = it.root
+    return it.root
+
+
+def normalize_indicator_id(indicator_id):
+    """Indicator ids sometimes have dashes or dots - standardize around dots."""
+    return indicator_id.replace('-', '.')
+
+
+def __get_series_from_series_code(series, dsd):
+    try:
+        dimension = next(item for item in dsd.dimensions if item.id == 'SERIES')
+        code = next(item for item in dimension.local_representation.enumerated if item.id == series)
+        return code
+    except:
+        return None
+
+
+def __get_annotation_text(concept, annotation_title):
+    try:
+        annotation = next(item for item in concept.annotations if item.title == annotation_title)
+        return str(annotation.text)
+    except:
+        return None
+
+
+def get_indicator_id_from_series_code(series_code, dsd_path=None, request_params=None):
+    """Convert a series code to an indicator ID (eg, "1.1.1")."""
+    dsd = get_dsd(dsd_path, request_params=request_params)
+    series = __get_series_from_series_code(series_code, dsd)
+    return __get_annotation_text(series, 'Indicator')
+
+
+def get_indicator_code_from_series_code(series_code, dsd_path=None, request_params=None):
+    """Convert a series code to an indicator code (eg, "C010101")."""
+    dsd = get_dsd(dsd_path, request_params=request_params)
+    series = __get_series_from_series_code(series_code, dsd)
+    return __get_annotation_text(series, 'IndicatorCode')
+
+
+def get_indicator_title_from_series_code(series_code, dsd_path=None, request_params=None):
+    """Convert a series code to an indicator title (eg, "Proportion of the...")."""
+    dsd = get_dsd(dsd_path, request_params=request_params)
+    series = __get_series_from_series_code(series_code, dsd)
+    return __get_annotation_text(series, 'IndicatorTitle')
+
+
+def __get_series_from_indicator_id(indicator_id, dsd):
+
+    indicator_id = normalize_indicator_id(indicator_id)
+    try:
+        dimension = next(item for item in dsd.dimensions if item.id == 'SERIES')
+        for code in dimension.local_representation.enumerated:
+            candidate = normalize_indicator_id(__get_annotation_text(code, 'Indicator'))
+            if candidate == indicator_id:
+                return code
+    except:
+        return None
+
+
+def __get_series_by_annotation_text(annotation_title, annotation_text, dsd):
+    try:
+        dimension = next(item for item in dsd.dimensions if item.id == 'SERIES')
+        for code in dimension.local_representation.enumerated:
+            candidate = __get_annotation_text(code, annotation_title)
+            if candidate == annotation_text:
+                return code
+    except:
+        return None
+
+
+def get_series_code_from_indicator_id(indicator_id, dsd_path=None, request_params=None):
+    """Convert an indicator ID (eg, "1.1.1") into a series code."""
+    dsd = get_dsd(dsd_path, request_params=request_params)
+    series = __get_series_from_indicator_id(indicator_id, dsd)
+    try:
+        return series.id
+    except:
+        return None
+
+
+def get_series_code_from_indicator_code(indicator_code, dsd_path=None, request_params=None):
+    """Convert an indicator code (eg, "C010101") into a series code."""
+    dsd = get_dsd(dsd_path, request_params=request_params)
+    series = __get_series_by_annotation_text('IndicatorCode', indicator_code, dsd)
+    try:
+        return series.id
+    except:
+        return None
+
+
+def get_series_code_from_indicator_title(indicator_title, dsd_path=None, request_params=None):
+    """Convert an indicator title (eg, "Proportion of the...") into a series code."""
+    dsd = get_dsd(dsd_path, request_params=request_params)
+    series = __get_series_by_annotation_text('IndicatorTitle', indicator_title, dsd)
+    try:
+        return series.id
+    except:
+        return None

--- a/sdg/helpers/sdmx.py
+++ b/sdg/helpers/sdmx.py
@@ -11,13 +11,13 @@ def get_dsd_url():
     return 'https://registry.sdmx.org/ws/public/sdmxapi/rest/datastructure/IAEG-SDGs/SDG/latest/?format=sdmx-2.1&detail=full&references=children'
 
 
-def get_dsd_message(path=None, request_params=None):
+def get_sdmx_message(path=None, request_params=None):
     if path is None:
         path = get_dsd_url()
-    if path in cache and 'get_dsd_message' in cache[path]:
-        return cache[path]['get_dsd_message']
+    if path in cache and 'get_sdmx_message' in cache[path]:
+        return cache[path]['get_sdmx_message']
     if path.startswith('http'):
-        filename = 'SDG_DSD.xml'
+        filename = 'SDG_MESSAGE.xml'
         files.download_remote_file(path, filename)
         msg = sdmx.read_sdmx(filename)
         os.remove(filename)
@@ -25,7 +25,7 @@ def get_dsd_message(path=None, request_params=None):
         msg = sdmx.read_sdmx(path)
     if path not in cache:
         cache[path] = {}
-    cache[path]['get_dsd_message'] = msg
+    cache[path]['get_sdmx_message'] = msg
     return msg
 
 
@@ -34,7 +34,7 @@ def get_dsd(path=None, request_params=None):
         path = get_dsd_url()
     if path in cache and 'get_dsd' in cache[path]:
         return cache[path]['get_dsd']
-    msg = get_dsd_message(path=path, request_params=request_params)
+    msg = get_sdmx_message(path=path, request_params=request_params)
     dsd_object = msg.structure[0]
     if path not in cache:
         cache[path] = {}

--- a/sdg/helpers/sdmx.py
+++ b/sdg/helpers/sdmx.py
@@ -68,32 +68,38 @@ def __get_series_from_series_code(series, dsd):
 
 
 def __get_annotation_text(concept, annotation_title):
+    matches = []
     try:
-        annotation = next(item for item in concept.annotations if item.title == annotation_title)
-        return str(annotation.text)
+        for item in concept.annotations:
+            if item.title == annotation_title:
+                matches.append(str(item.text))
     except:
-        return None
+        pass
+    return matches
 
 
 def get_indicator_id_from_series_code(series_code, dsd_path=None, request_params=None):
     """Convert a series code to an indicator ID (eg, "1.1.1")."""
     dsd = get_dsd(dsd_path, request_params=request_params)
     series = __get_series_from_series_code(series_code, dsd)
-    return __get_annotation_text(series, 'Indicator')
+    matches = __get_annotation_text(series, 'Indicator')
+    return matches[0] if len(matches) > 0 else None
 
 
 def get_indicator_code_from_series_code(series_code, dsd_path=None, request_params=None):
     """Convert a series code to an indicator code (eg, "C010101")."""
     dsd = get_dsd(dsd_path, request_params=request_params)
     series = __get_series_from_series_code(series_code, dsd)
-    return __get_annotation_text(series, 'IndicatorCode')
+    matches = __get_annotation_text(series, 'IndicatorCode')
+    return matches[0] if len(matches) > 0 else None
 
 
 def get_indicator_title_from_series_code(series_code, dsd_path=None, request_params=None):
     """Convert a series code to an indicator title (eg, "Proportion of the...")."""
     dsd = get_dsd(dsd_path, request_params=request_params)
     series = __get_series_from_series_code(series_code, dsd)
-    return __get_annotation_text(series, 'IndicatorTitle')
+    matches = __get_annotation_text(series, 'IndicatorTitle')
+    return matches[0] if len(matches) > 0 else None
 
 
 def __get_series_from_indicator_id(indicator_id, dsd):
@@ -102,9 +108,11 @@ def __get_series_from_indicator_id(indicator_id, dsd):
     try:
         dimension = next(item for item in dsd.dimensions if item.id == 'SERIES')
         for code in dimension.local_representation.enumerated:
-            candidate = normalize_indicator_id(__get_annotation_text(code, 'Indicator'))
-            if candidate == indicator_id:
-                return code
+            matches = __get_annotation_text(code, 'Indicator')
+            for annotation_text in matches:
+                candidate = normalize_indicator_id(annotation_text)
+                if candidate == indicator_id:
+                    return code
     except:
         return None
 
@@ -113,9 +121,10 @@ def __get_series_by_annotation_text(annotation_title, annotation_text, dsd):
     try:
         dimension = next(item for item in dsd.dimensions if item.id == 'SERIES')
         for code in dimension.local_representation.enumerated:
-            candidate = __get_annotation_text(code, annotation_title)
-            if candidate == annotation_text:
-                return code
+            matches = __get_annotation_text(code, annotation_title)
+            for candidate in matches:
+                if candidate == annotation_text:
+                    return code
     except:
         return None
 

--- a/sdg/helpers/sdmx.py
+++ b/sdg/helpers/sdmx.py
@@ -11,11 +11,11 @@ def get_dsd_url():
     return 'https://registry.sdmx.org/ws/public/sdmxapi/rest/datastructure/IAEG-SDGs/SDG/latest/?format=sdmx-2.1&detail=full&references=children'
 
 
-def get_dsd(path=None, request_params=None):
+def get_dsd_message(path=None, request_params=None):
     if path is None:
         path = get_dsd_url()
-    if path in cache and 'get_dsd' in cache[path]:
-        return cache[path]['get_dsd']
+    if path in cache and 'get_dsd_message' in cache[path]:
+        return cache[path]['get_dsd_message']
     if path.startswith('http'):
         filename = 'SDG_DSD.xml'
         files.download_remote_file(path, filename)
@@ -23,6 +23,18 @@ def get_dsd(path=None, request_params=None):
         os.remove(filename)
     else:
         msg = sdmx.read_sdmx(path)
+    if path not in cache:
+        cache[path] = {}
+    cache[path]['get_dsd_message'] = msg
+    return msg
+
+
+def get_dsd(path=None, request_params=None):
+    if path is None:
+        path = get_dsd_url()
+    if path in cache and 'get_dsd' in cache[path]:
+        return cache[path]['get_dsd']
+    msg = get_dsd_message(path=path, request_params=request_params)
     dsd_object = msg.structure[0]
     if path not in cache:
         cache[path] = {}

--- a/sdg/inputs/InputBase.py
+++ b/sdg/inputs/InputBase.py
@@ -3,6 +3,7 @@ import pandas as pd
 import numpy as np
 from sdg.Indicator import Indicator
 from sdg.Loggable import Loggable
+from sdg import helpers
 
 class InputBase(Loggable):
     """Base class for sources of SDG data/metadata."""
@@ -99,23 +100,7 @@ class InputBase(Loggable):
 
 
     def fetch_file(self, location):
-        """Fetch a file, either on disk, or on the Internet.
-
-        Parameters
-        ----------
-        location : String
-            Either an http address, or a path on disk
-        """
-        file = None
-        data = None
-        if location.startswith('http'):
-            file = urlopen(location)
-            data = file.read().decode('utf-8')
-        else:
-            file = open(location)
-            data = file.read()
-        file.close()
-        return data
+        return helpers.files.read_file(location)
 
 
     def normalize_indicator_id(self, indicator_id):

--- a/sdg/inputs/InputBase.py
+++ b/sdg/inputs/InputBase.py
@@ -6,7 +6,15 @@ from sdg.Loggable import Loggable
 from sdg import helpers
 
 class InputBase(Loggable):
-    """Base class for sources of SDG data/metadata."""
+    """Base class for sources of SDG data/metadata.
+
+    logging: None or list
+        Type of logs to print, including 'warn' and 'debug'.
+    request_params : dict or None
+        Optional dict of parameters to be passed to remote file fetches.
+        Corresponds to the options passed to a urllib.request.Request.
+        @see https://docs.python.org/3/library/urllib.request.html#urllib.request.Request
+    """
 
     def __init__(self, logging=None, request_params=None):
         """Constructor for InputBase."""

--- a/sdg/inputs/InputBase.py
+++ b/sdg/inputs/InputBase.py
@@ -8,9 +8,10 @@ from sdg import helpers
 class InputBase(Loggable):
     """Base class for sources of SDG data/metadata."""
 
-    def __init__(self, logging=None):
+    def __init__(self, logging=None, request_params=None):
         """Constructor for InputBase."""
         Loggable.__init__(self, logging=logging)
+        self.request_params = request_params
         self.indicators = {}
         self.data_alterations = []
         self.meta_alterations = []
@@ -100,7 +101,7 @@ class InputBase(Loggable):
 
 
     def fetch_file(self, location):
-        return helpers.files.read_file(location)
+        return helpers.files.read_file(location, request_params=self.request_params)
 
 
     def normalize_indicator_id(self, indicator_id):

--- a/sdg/inputs/InputSdmx.py
+++ b/sdg/inputs/InputSdmx.py
@@ -23,7 +23,8 @@ class InputSdmx(InputBase):
                  dsd='https://registry.sdmx.org/ws/public/sdmxapi/rest/datastructure/IAEG-SDGs/SDG/latest/?format=sdmx-2.1&detail=full&references=children',
                  indicator_id_xpath=".//Annotation[AnnotationTitle='Indicator']/AnnotationText",
                  indicator_name_xpath=".//Annotation[AnnotationTitle='IndicatorTitle']/AnnotationText",
-                 logging=None):
+                 logging=None,
+                 request_params=None):
         """Constructor for InputSdmx.
 
         Parameters
@@ -92,7 +93,7 @@ class InputSdmx(InputBase):
 
 
     def parse_xml(self, location, strip_namespaces=True):
-        return helpers.sdmx.parse_xml(location)
+        return helpers.sdmx.parse_xml(location, request_params=self.request_params)
 
 
     def dimension_id_to_codelist_id(self, dimension_id):

--- a/sdg/inputs/InputSdmx.py
+++ b/sdg/inputs/InputSdmx.py
@@ -4,6 +4,7 @@ from xml.etree import ElementTree as ET
 from io import StringIO
 import pandas as pd
 import numpy as np
+from sdg import helpers
 
 class InputSdmx(InputBase):
     """Sources of SDG data that are SDMX format."""
@@ -91,23 +92,7 @@ class InputSdmx(InputBase):
 
 
     def parse_xml(self, location, strip_namespaces=True):
-        """Fetch and parse an XML file.
-
-        Parameters
-        ----------
-        location : string
-            Remote URL of the XML file or path to local file.
-        strip_namespaces : boolean
-            Whether or not to strip namespaces. This is helpful in cases where
-            different implementations may use different namespaces/prefixes.
-        """
-        xml = self.fetch_file(location)
-        it = ET.iterparse(StringIO(xml))
-        if strip_namespaces:
-            for _, el in it:
-                if '}' in el.tag:
-                    el.tag = el.tag.split('}', 1)[1]
-        return it.root
+        return helpers.sdmx.parse_xml(location)
 
 
     def dimension_id_to_codelist_id(self, dimension_id):

--- a/sdg/outputs/OutputBase.py
+++ b/sdg/outputs/OutputBase.py
@@ -9,7 +9,7 @@ class OutputBase(Loggable):
 
 
     def __init__(self, inputs, schema, output_folder='_site', translations=None,
-                 indicator_options=None, logging=None):
+                 indicator_options=None, logging=None, request_params=None):
         """Constructor for OutputBase.
 
         inputs: list
@@ -25,8 +25,11 @@ class OutputBase(Loggable):
             Allows particular outputs to affect the data/metadata of indicators.
         logging: None or list
             Type of logs to print, including 'warn' and 'debug'.
+        request_params : dict or None
+            Optional dict of parameters to be passed to remote file fetches
         """
         Loggable.__init__(self, logging=logging)
+        self.request_params = request_params
         if translations is None:
             translations = []
         self.indicator_options = IndicatorOptions() if indicator_options is None else indicator_options

--- a/sdg/outputs/OutputBase.py
+++ b/sdg/outputs/OutputBase.py
@@ -26,7 +26,9 @@ class OutputBase(Loggable):
         logging: None or list
             Type of logs to print, including 'warn' and 'debug'.
         request_params : dict or None
-            Optional dict of parameters to be passed to remote file fetches
+            Optional dict of parameters to be passed to remote file fetches.
+            Corresponds to the options passed to a urllib.request.Request.
+            @see https://docs.python.org/3/library/urllib.request.html#urllib.request.Request
         """
         Loggable.__init__(self, logging=logging)
         self.request_params = request_params

--- a/sdg/outputs/OutputSdmxMl.py
+++ b/sdg/outputs/OutputSdmxMl.py
@@ -32,7 +32,7 @@ class OutputSdmxMl(OutputBase):
     def __init__(self, inputs, schema, output_folder='_site', translations=None,
                  indicator_options=None, dsd=None, default_values=None,
                  header_id=None, sender_id=None, structure_specific=False,
-                 column_map=None, code_map=None):
+                 column_map=None, code_map=None, request_params=None):
 
         """Constructor for OutputSdmxMl.
 
@@ -72,7 +72,8 @@ class OutputSdmxMl(OutputBase):
         code_map: string
             Remote URL of CSV code mapping or path to local CSV code mapping file
         """
-        OutputBase.__init__(self, inputs, schema, output_folder, translations, indicator_options)
+        OutputBase.__init__(self, inputs, schema, output_folder, translations,
+            indicator_options, request_params=request_params)
         self.header_id = header_id
         self.sender_id = sender_id
         self.structure_specific = structure_specific
@@ -87,7 +88,7 @@ class OutputSdmxMl(OutputBase):
 
 
     def retrieve_dsd(self, dsd):
-        self.dsd = helpers.sdmx.get_dsd(dsd)
+        self.dsd = helpers.sdmx.get_dsd(dsd, request_params=self.request_params)
 
 
     def build(self, language=None):

--- a/sdg/outputs/OutputSdmxMl.py
+++ b/sdg/outputs/OutputSdmxMl.py
@@ -23,14 +23,16 @@ from sdmx.message import (
 )
 from urllib.request import urlretrieve
 from sdg.outputs import OutputBase
+from sdg import helpers
 
 class OutputSdmxMl(OutputBase):
     """Output SDG data/metadata in SDMX-ML."""
 
 
     def __init__(self, inputs, schema, output_folder='_site', translations=None,
-                 indicator_options=None, dsd='https://registry.sdmx.org/ws/public/sdmxapi/rest/datastructure/IAEG-SDGs/SDG/latest/?format=sdmx-2.1&detail=full&references=children',
-                 default_values=None, header_id=None, sender_id=None, structure_specific=False, column_map=None, code_map=None):
+                 indicator_options=None, dsd=None, default_values=None,
+                 header_id=None, sender_id=None, structure_specific=False,
+                 column_map=None, code_map=None):
 
         """Constructor for OutputSdmxMl.
 
@@ -85,12 +87,7 @@ class OutputSdmxMl(OutputBase):
 
 
     def retrieve_dsd(self, dsd):
-        if dsd.startswith('http'):
-            urlretrieve(dsd, 'SDG_DSD.xml')
-            dsd = 'SDG_DSD.xml'
-        msg = sdmx.read_sdmx(dsd)
-        dsd_object = msg.structure[0]
-        self.dsd = dsd_object
+        self.dsd = helpers.sdmx.get_dsd(dsd)
 
 
     def build(self, language=None):
@@ -108,7 +105,7 @@ class OutputSdmxMl(OutputBase):
         for indicator_id in self.get_indicator_ids():
             indicator = self.get_indicator_by_id(indicator_id).language(language)
             data = indicator.data.copy()
-            
+
             # Map column names to SDMX dimension/attribute names
             if self.column_map is not None:
                 column_map=pd.read_csv(self.column_map)
@@ -116,7 +113,7 @@ class OutputSdmxMl(OutputBase):
                     if col in column_map['Text'].to_list():
                         newcol=column_map['Value'].loc[column_map['Text']==col].iloc[0]
                         data.rename(columns={col:newcol}, inplace=True)
-            
+
             # Map column values to SDMX codes within specific dimensions/attributes
             if self.code_map is not None:
                 code_map=pd.read_csv(self.code_map)

--- a/sdg/schemas/SchemaInputBase.py
+++ b/sdg/schemas/SchemaInputBase.py
@@ -23,7 +23,9 @@ class SchemaInputBase(Loggable):
         scope : string
             An optional 'scope' to apply to all metadata fields
         request_params : dict or None
-            Optional dict of parameters to be passed to remote file fetches
+            Optional dict of parameters to be passed to remote file fetches.
+            Corresponds to the options passed to a urllib.request.Request.
+            @see https://docs.python.org/3/library/urllib.request.html#urllib.request.Request
         """
 
         Loggable.__init__(self, logging=logging)

--- a/sdg/schemas/SchemaInputBase.py
+++ b/sdg/schemas/SchemaInputBase.py
@@ -12,7 +12,8 @@ class SchemaInputBase(Loggable):
     This class assumes imported schema (self.schema) are valid JSON Schema."""
 
 
-    def __init__(self, schema_path='', logging=None, scope=None):
+    def __init__(self, schema_path='', logging=None, scope=None,
+        request_params=None):
         """Create a new SchemaBase object
 
         Parameters
@@ -21,11 +22,14 @@ class SchemaInputBase(Loggable):
             A path to the schema file to input
         scope : string
             An optional 'scope' to apply to all metadata fields
+        request_params : dict or None
+            Optional dict of parameters to be passed to remote file fetches
         """
 
         Loggable.__init__(self, logging=logging)
         self.schema_path = schema_path
         self.scope = scope
+        self.request_params = request_params
         self.field_order = []
         self.schema = None
         self.load_schema()

--- a/sdg/schemas/SchemaInputSdmxMsd.py
+++ b/sdg/schemas/SchemaInputSdmxMsd.py
@@ -39,8 +39,8 @@ class SchemaInputSdmxMsd(SchemaInputBase):
         self.schema = schema
 
     def parse_xml(self, location, strip_namespaces=True):
-        return helpers.sdmx.parse_xml(location)
+        return helpers.sdmx.parse_xml(location, request_params=self.request_params)
 
 
     def fetch_file(self, location):
-        return helpers.files.read_file(location)
+        return helpers.files.read_file(location, request_params=self.request_params)

--- a/sdg/schemas/SchemaInputSdmxMsd.py
+++ b/sdg/schemas/SchemaInputSdmxMsd.py
@@ -3,6 +3,7 @@ from urllib.request import urlopen
 from xml.etree import ElementTree as ET
 from io import StringIO
 from sdg.schemas import SchemaInputBase
+from sdg import helpers
 
 class SchemaInputSdmxMsd(SchemaInputBase):
     """Input schema from SDMX MSD."""
@@ -38,40 +39,8 @@ class SchemaInputSdmxMsd(SchemaInputBase):
         self.schema = schema
 
     def parse_xml(self, location, strip_namespaces=True):
-        """Fetch and parse an XML file.
-
-        Parameters
-        ----------
-        location : string
-            Remote URL of the XML file or path to local file.
-        strip_namespaces : boolean
-            Whether or not to strip namespaces. This is helpful in cases where
-            different implementations may use different namespaces/prefixes.
-        """
-        xml = self.fetch_file(location)
-        it = ET.iterparse(StringIO(xml))
-        if strip_namespaces:
-            for _, el in it:
-                if '}' in el.tag:
-                    el.tag = el.tag.split('}', 1)[1]
-        return it.root
+        return helpers.sdmx.parse_xml(location)
 
 
     def fetch_file(self, location):
-        """Fetch a file, either on disk, or on the Internet.
-
-        Parameters
-        ----------
-        location : String
-            Either an http address, or a path on disk
-        """
-        file = None
-        data = None
-        if location.startswith('http'):
-            file = urlopen(location)
-            data = file.read().decode('utf-8')
-        else:
-            file = open(location)
-            data = file.read()
-        file.close()
-        return data
+        return helpers.files.read_file(location)

--- a/sdg/translations/TranslationInputBase.py
+++ b/sdg/translations/TranslationInputBase.py
@@ -4,6 +4,7 @@ import os
 from git import Repo
 from urllib.request import urlopen
 from sdg.Loggable import Loggable
+from sdg import helpers
 
 class TranslationInputBase(Loggable):
     """A base class for importing translations."""
@@ -74,23 +75,7 @@ class TranslationInputBase(Loggable):
 
 
     def fetch_file(self, location):
-        """Fetch a file, either on disk, or on the Internet.
-
-        Parameters
-        ----------
-        location : String
-            Either an http address, or a path on disk
-        """
-        file = None
-        data = None
-        if location.startswith('http'):
-            file = urlopen(location)
-            data = file.read().decode('utf-8')
-        else:
-            file = open(location)
-            data = file.read()
-        file.close()
-        return data
+        return helpers.files.read_file(location)
 
 
     def clone_repo(self, repo_url, folder='temp', tag=None, branch=None):

--- a/sdg/translations/TranslationInputBase.py
+++ b/sdg/translations/TranslationInputBase.py
@@ -10,7 +10,7 @@ class TranslationInputBase(Loggable):
     """A base class for importing translations."""
 
 
-    def __init__(self, source='', logging=None):
+    def __init__(self, source='', logging=None, request_params=None):
         """Constructor for the TranslationInputBase class.
 
         Parameters
@@ -19,6 +19,7 @@ class TranslationInputBase(Loggable):
             The source of the translations (see subclass for details)
         """
         Loggable.__init__(self, logging=logging)
+        self.request_params = request_params
         self.source = source
         self.translations = {}
         self.executed = False
@@ -75,7 +76,7 @@ class TranslationInputBase(Loggable):
 
 
     def fetch_file(self, location):
-        return helpers.files.read_file(location)
+        return helpers.files.read_file(location, request_params=self.request_params)
 
 
     def clone_repo(self, repo_url, folder='temp', tag=None, branch=None):

--- a/sdg/translations/TranslationInputSdmx.py
+++ b/sdg/translations/TranslationInputSdmx.py
@@ -3,6 +3,7 @@
 from xml.etree import ElementTree as ET
 from io import StringIO
 from sdg.translations import TranslationInputBase
+from sdg import helpers
 
 class TranslationInputSdmx(TranslationInputBase):
     """A class for importing translations from an SDMX DSD.
@@ -38,30 +39,7 @@ class TranslationInputSdmx(TranslationInputBase):
 
 
     def parse_xml(self, location, strip_namespaces=True):
-        """Fetch and parse an XML file.
-
-        Parameters
-        ----------
-        location : string
-            Remote URL of the XML file or path to local file.
-        strip_namespaces : boolean
-            Whether or not to strip namespaces. This is helpful in cases where
-            different implementations may use different namespaces/prefixes.
-        """
-        xml = self.fetch_file(location)
-        it = ET.iterparse(StringIO(xml))
-        if strip_namespaces:
-            for _, el in it:
-                if '}' in el.tag:
-                    el.tag = el.tag.split('}', 1)[1]
-                for attrib in list(el.attrib.keys()):
-                    if '}' in attrib:
-                        val = el.attrib[attrib]
-                        del el.attrib[attrib]
-                        attrib = attrib.split('}', 1)[1]
-                        el.attrib[attrib] = val
-
-        return it.root
+        return helpers.sdmx.parse_xml(location)
 
 
     def execute(self):

--- a/sdg/translations/TranslationInputSdmx.py
+++ b/sdg/translations/TranslationInputSdmx.py
@@ -22,7 +22,8 @@ class TranslationInputSdmx(TranslationInputBase):
     you will need to use the same "dimension_map" here.
     """
 
-    def __init__(self, source='', dimension_map=None, logging=None):
+    def __init__(self, source='', dimension_map=None, logging=None,
+        request_params=None):
         """Constructor for the TranslationInputSdmx class.
 
         Parameters
@@ -35,11 +36,12 @@ class TranslationInputSdmx(TranslationInputBase):
         if dimension_map is None:
             dimension_map = {}
         self.dimension_map = dimension_map
-        TranslationInputBase.__init__(self, source=source, logging=logging)
+        TranslationInputBase.__init__(self, source=source, logging=logging,
+            request_params=request_params)
 
 
     def parse_xml(self, location, strip_namespaces=True):
-        return helpers.sdmx.parse_xml(location)
+        return helpers.sdmx.parse_xml(location, request_params=self.request_params)
 
 
     def execute(self):


### PR DESCRIPTION
This moves some commonly used file-related and SDMX-related code to dedicated files, where they can be re-used across classes. Some of the code in various classes is replaced with calls to these functions. Any class that needs to make remote calls has a new parameter called "request_params" which can be used to control the behavior of remote requests.

Six new helper functions are included -- but not used -- that may be useful in working with series codes in SDMX:

  * get_indicator_id_from_series_code
  * get_indicator_code_from_series_code
  * get_indicator_title_from_series_code
  * get_series_code_from_indicator_id
  * get_series_code_from_indicator_code
  * get_series_code_from_indicator_title