### PR TITLE
New automated metadata fields for Git dates (only)

### DIFF
--- a/sdg/inputs/InputMetaFiles.py
+++ b/sdg/inputs/InputMetaFiles.py
@@ -83,6 +83,14 @@ class InputMetaFiles(InputFiles):
         git_update = self.get_git_dates(meta, filepath)
         for k in git_update.keys():
             meta[k] = git_update[k]
+        # @deprecated start
+        # For now continue to populate the deprecated link fields:
+        # * national_metadata_update_url / national_metadata_update_url_text
+        # * national_data_update_url / national_data_update_url_text
+        deprecated_fields = self.get_git_updates(meta, filepath)
+        for k in deprecated_fields.keys():
+            meta[k] = deprecated_fields[k]
+        # @deprecated end
 
 
     def get_git_dates(self, meta, filepath):
@@ -115,10 +123,7 @@ class InputMetaFiles(InputFiles):
 
 
     # @deprecated start
-    # This method is no longer used, but left in in case it
-    # was used by downstream subclasses.
     def get_git_updates(self, meta, filepath):
-        print('The get_git_updates() method is deprecated and will be removed in 2.0.0.')
         meta_update = self.get_git_update(filepath)
         updates = {
             'national_metadata_update_url_text': meta_update['date'] + ': see changes on GitHub',
@@ -140,12 +145,9 @@ class InputMetaFiles(InputFiles):
     # @deprecated end
 
     # @deprecated start
-    # This method is no longer used, but left in in case it
-    # was used by downstream subclasses.
     def get_git_update(self, filepath):
         """Change into the working directory of the file (it might be a submodule)
         and get the latest git history"""
-        print('The get_git_update() method is deprecated and will be removed in 2.0.0.')
         folder = os.path.split(filepath)[0]
 
         repo = git.Repo(folder, search_parent_directories=True)

--- a/sdg/inputs/InputMetaFiles.py
+++ b/sdg/inputs/InputMetaFiles.py
@@ -95,7 +95,7 @@ class InputMetaFiles(InputFiles):
 
     def get_git_dates(self, meta, filepath):
         updates = {}
-        updates['national_metadata_last_updated'] = self.get_git_date(filepath)
+        updates['national_metadata_updated_date'] = self.get_git_date(filepath)
         if 'data_filename' in meta:
             data_filename = meta['data_filename']
         else:
@@ -104,7 +104,7 @@ class InputMetaFiles(InputFiles):
         src_dir = os.path.dirname(os.path.dirname(self.path_pattern))
         data_filepath = os.path.join(src_dir, self.git_data_dir, data_filename)
         if os.path.isfile(data_filepath):
-            updates['national_data_last_updated'] = self.get_git_date(data_filepath)
+            updates['national_data_updated_date'] = self.get_git_date(data_filepath)
 
         return updates
 

--- a/tests/_prose.yml
+++ b/tests/_prose.yml
@@ -51,12 +51,12 @@ prose:
             label: "Global indicator description"
             scope: global
       - name: "un_designated_tier"
-        field: 
+        field:
             element: text
             label: "UN designated tier"
             scope: global
       - name: "un_custodian_agency"
-        field: 
+        field:
             element: text
             label: "UN custodian agency"
             scope: global
@@ -107,30 +107,20 @@ prose:
             element: text
             label: "Other information"
             scope: national
-      - name: "national_data_update_url"
+      - name: "national_data_last_updated"
         field:
             element: hidden
             label: "Data last updated"
             scope: national
-      - name: "national_data_update_url_text"
-        field:
-            element: hidden
-            label: "Data last updated"
-            scope: national
-      - name: "national_metadata_update_url"
-        field:
-            element: hidden
-            label: "Metadata last updated"
-            scope: national
-      - name: "national_metadata_update_url_text"
+      - name: "national_metadata_last_updated"
         field:
             element: hidden
             label: "Metadata last updated"
             scope: national
        ######### Data Info #########
       - name: "reporting_status"
-        field: 
-            element: select 
+        field:
+            element: select
             label: "Reporting status"
             options:
               - name: 'Exploring data sources'
@@ -177,8 +167,8 @@ prose:
             scope: data
       ######### Chart Info #########
       - name: "graph_type"
-        field: 
-            element: select 
+        field:
+            element: select
             label: "Graph type"
             options:
               - name: 'line'
@@ -187,7 +177,7 @@ prose:
                 value: 'bar'
             scope: graph
       - name: "graph_title"
-        field: 
+        field:
             element: text
             label: "Graph Title"
             scope: graph

--- a/tests/_prose.yml
+++ b/tests/_prose.yml
@@ -107,12 +107,12 @@ prose:
             element: text
             label: "Other information"
             scope: national
-      - name: "national_data_last_updated"
+      - name: "national_data_updated_date"
         field:
             element: hidden
             label: "Data last updated"
             scope: national
-      - name: "national_metadata_last_updated"
+      - name: "national_metadata_updated_date"
         field:
             element: hidden
             label: "Metadata last updated"


### PR DESCRIPTION
Fixes https://github.com/open-sdg/open-sdg/issues/1051

Note: This adds new metadata fields called "national_data_last_updated" and "national_metadata_last_updated", and automatically sets them with the Git date (only). The old fields will continue to be populated, for backwards compatibility. To use the new field and remove the old fields, users will need to change their metadata schema (eg, _prose.yml), like so:

Remove these:
* national_metadata_update_url
* national_metadata_update_url_text
* national_data_update_url
* national_data_update_url_text

Add these:
* national_metadata_updated_date
* national_data_updated_date

