### PR TITLE
Do not sort datapackage schemas that were intentionally specified

### DIFF
--- a/sdg/outputs/OutputDataPackage.py
+++ b/sdg/outputs/OutputDataPackage.py
@@ -72,7 +72,9 @@ class OutputDataPackage(OutputBase):
         self.create_top_level_package('all', 'All indicators')
 
         backup_data_schema = DataSchemaInputIndicator(source=self.indicators)
+        data_schema_not_specified = False
         if self.data_schema is None:
+            data_schema_not_specified = True
             self.data_schema = backup_data_schema
 
         for indicator_id in self.get_indicator_ids():
@@ -81,13 +83,17 @@ class OutputDataPackage(OutputBase):
             Path(package_folder).mkdir(parents=True, exist_ok=True)
 
             indicator = self.get_indicator_by_id(indicator_id).language(language)
+            backup_schema_was_used = False
             data_schema_for_indicator = self.data_schema.get_schema_for_indicator(indicator)
             if data_schema_for_indicator is None:
+                backup_schema_was_used = True
                 data_schema_for_indicator = backup_data_schema.get_schema_for_indicator(indicator)
 
             # Clone the schema so that it can be sorted and translated.
             data_schema_for_indicator = Schema(dict(data_schema_for_indicator))
-            if self.sorting != 'default':
+            # We only sort the schema if it was not specified or if
+            # the backup schema was used.
+            if data_schema_not_specified or backup_schema_was_used:
                 self.sort_data_schema(data_schema_for_indicator)
             if language is not None:
                 self.translate_data_schema(data_schema_for_indicator, language)


### PR DESCRIPTION
This tweak prevents the datapackage sorting logic from applying to datapackage schemas that were intentionally provided. The assumption is that if the schemas were intentionally provided then their sorting should be left alone.