### PR TITLE
Fix empty values by column to avoid datatype issues

### DIFF
--- a/sdg/inputs/InputBase.py
+++ b/sdg/inputs/InputBase.py
@@ -97,7 +97,14 @@ class InputBase(Loggable):
         Dataframe
             The same dataframe with rearranged columns
         """
-        return df.replace([None, "", "nan"], np.NaN)
+        to_replace = {
+            None: np.NaN,
+            "": np.NaN,
+            "nan": np.NaN
+        }
+        for col in df.columns:
+            df[col].replace(to_replace=to_replace, inplace=True)
+        return df
 
 
     def fetch_file(self, location):


### PR DESCRIPTION
The way that we are fixing empty values is apparently problematic. It randomly changes the datatype of data. For example, the string "2010" can change to the float 2010.0.

More discussion here: https://stackoverflow.com/questions/59500812/pandas-dataframe-replace-change-dtype-of-columns