### PR TITLE
Allow suffix on imported metadata keys

### DIFF
--- a/sdg/inputs/InputBase.py
+++ b/sdg/inputs/InputBase.py
@@ -6,12 +6,9 @@ from sdg.Loggable import Loggable
 from sdg import helpers
 
 class InputBase(Loggable):
-    """Base class for sources of SDG data/metadata."""
+    """Base class for sources of SDG data/metadata.
 
-    def __init__(self, logging=None, column_map=None, code_map=None, request_params=None,
-                 meta_suffix=None):
-        """Constructor for InputBase.
-        logging : list
+    logging : list
             List of types of log message to output. Values can include 'debug' or 'warn'.
         column_map: string
             Remote URL of CSV column mapping or path to local CSV column mapping file
@@ -26,7 +23,11 @@ class InputBase(Loggable):
             Optional dict of parameters to be passed to remote file fetches.
             Corresponds to the options passed to a urllib.request.Request.
             @see https://docs.python.org/3/library/urllib.request.html#urllib.request.Request
-        """
+    """
+
+    def __init__(self, logging=None, column_map=None, code_map=None, request_params=None,
+                 meta_suffix=None):
+        """Constructor for InputBase."""
         Loggable.__init__(self, logging=logging)
         self.request_params = request_params
         self.indicators = {}

--- a/sdg/inputs/InputBase.py
+++ b/sdg/inputs/InputBase.py
@@ -7,8 +7,18 @@ from sdg.Loggable import Loggable
 class InputBase(Loggable):
     """Base class for sources of SDG data/metadata."""
 
-    def __init__(self, logging=None, column_map=None, code_map=None):
-        """Constructor for InputBase."""
+    def __init__(self, logging=None, column_map=None, code_map=None, meta_suffix=None):
+        """Constructor for InputBase.
+        logging : list
+            List of types of log message to output. Values can include 'debug' or 'warn'.
+        column_map: string
+            Remote URL of CSV column mapping or path to local CSV column mapping file
+        code_map: string
+            Remote URL of CSV code mapping or path to local CSV code mapping file
+        meta_suffix: string
+            String to add to each metadata key. Intended usage is to allow identical
+            sets of metadata - one for global and one for national.
+        """
         Loggable.__init__(self, logging=logging)
         self.indicators = {}
         self.data_alterations = []
@@ -19,6 +29,7 @@ class InputBase(Loggable):
         self.num_previously_merged_inputs = 0
         self.column_map = column_map
         self.code_map = code_map
+        self.meta_suffix = meta_suffix
 
 
     def execute_once(self, indicator_options):
@@ -238,6 +249,10 @@ class InputBase(Loggable):
                 return meta
         for alteration in self.meta_alterations:
             meta = alteration(meta)
+        if self.meta_suffix is not None:
+            for key in meta:
+                meta[key + self.meta_suffix] = meta[key]
+                del meta[key]
         return meta
 
 

--- a/sdg/inputs/InputBase.py
+++ b/sdg/inputs/InputBase.py
@@ -250,9 +250,10 @@ class InputBase(Loggable):
         for alteration in self.meta_alterations:
             meta = alteration(meta)
         if self.meta_suffix is not None:
-            for key in meta:
-                meta[key + self.meta_suffix] = meta[key]
-                del meta[key]
+            for key in list(meta.keys()):
+                if not key.endswith(self.meta_suffix):
+                    meta[key + self.meta_suffix] = meta[key]
+                    del meta[key]
         return meta
 
 

--- a/sdg/inputs/InputBase.py
+++ b/sdg/inputs/InputBase.py
@@ -8,9 +8,9 @@ from sdg import helpers
 class InputBase(Loggable):
     """Base class for sources of SDG data/metadata.
 
-    logging : None or list
+    logging: None or list
         Type of logs to print, including 'warn' and 'debug'.
-    request_params: dict or None
+    request_params : dict or None
         Optional dict of parameters to be passed to remote file fetches.
         Corresponds to the options passed to a urllib.request.Request.
         @see https://docs.python.org/3/library/urllib.request.html#urllib.request.Request

--- a/sdg/inputs/InputBase.py
+++ b/sdg/inputs/InputBase.py
@@ -8,21 +8,19 @@ from sdg import helpers
 class InputBase(Loggable):
     """Base class for sources of SDG data/metadata.
 
-    logging : list
-            List of types of log message to output. Values can include 'debug' or 'warn'.
-        column_map: string
-            Remote URL of CSV column mapping or path to local CSV column mapping file
-        code_map: string
-            Remote URL of CSV code mapping or path to local CSV code mapping file
-        meta_suffix: string
-            String to add to each metadata key. Intended usage is to allow identical
-            sets of metadata - one for global and one for national.
-        logging: None or list
-            Type of logs to print, including 'warn' and 'debug'.
-        request_params : dict or None
-            Optional dict of parameters to be passed to remote file fetches.
-            Corresponds to the options passed to a urllib.request.Request.
-            @see https://docs.python.org/3/library/urllib.request.html#urllib.request.Request
+    logging : None or list
+        Type of logs to print, including 'warn' and 'debug'.
+    request_params: dict or None
+        Optional dict of parameters to be passed to remote file fetches.
+        Corresponds to the options passed to a urllib.request.Request.
+        @see https://docs.python.org/3/library/urllib.request.html#urllib.request.Request
+    column_map: string
+        Remote URL of CSV column mapping or path to local CSV column mapping file
+    code_map: string
+        Remote URL of CSV code mapping or path to local CSV code mapping file
+    meta_suffix: string
+        String to add to each metadata key. Intended usage is to allow identical
+        sets of metadata - one for global and one for national.
     """
 
     def __init__(self, logging=None, column_map=None, code_map=None, request_params=None,

--- a/sdg/inputs/InputSdmx.py
+++ b/sdg/inputs/InputSdmx.py
@@ -23,7 +23,8 @@ class InputSdmx(InputBase):
                  indicator_id_xpath=".//Annotation[AnnotationTitle='Indicator']/AnnotationText",
                  indicator_name_xpath=".//Annotation[AnnotationTitle='IndicatorTitle']/AnnotationText",
                  logging=None,
-                 column_map=None, code_map=None):
+                 column_map=None, code_map=None,
+                 meta_suffix=None):
         """Constructor for InputSdmx.
 
         Parameters
@@ -66,7 +67,7 @@ class InputSdmx(InputBase):
             An xpath query to find the indicator name within each Series code
         """
         InputBase.__init__(self, logging=logging, column_map=column_map,
-            code_map=code_map)
+            code_map=code_map, meta_suffix=meta_suffix)
         if drop_dimensions is None:
             drop_dimensions = []
         if dimension_map is None:

--- a/sdg/inputs/InputSdmx.py
+++ b/sdg/inputs/InputSdmx.py
@@ -69,8 +69,7 @@ class InputSdmx(InputBase):
             An xpath query to find the indicator name within each Series code
         """
         InputBase.__init__(self, logging=logging, column_map=column_map,
-                           code_map=code_map, meta_suffix=meta_suffix,
-                           request_params=request_params)
+            code_map=code_map, request_params=request_params, meta_suffix=meta_suffix)
         if drop_dimensions is None:
             drop_dimensions = []
         if dimension_map is None:

--- a/sdg/schemas/SchemaInputBase.py
+++ b/sdg/schemas/SchemaInputBase.py
@@ -13,7 +13,7 @@ class SchemaInputBase(Loggable):
 
 
     def __init__(self, schema_path='', logging=None, scope=None,
-                 request_params=None, meta_suffix=None):
+        request_params=None, meta_suffix=None):
         """Create a new SchemaBase object
 
         Parameters

--- a/sdg/schemas/SchemaInputBase.py
+++ b/sdg/schemas/SchemaInputBase.py
@@ -12,7 +12,7 @@ class SchemaInputBase(Loggable):
     This class assumes imported schema (self.schema) are valid JSON Schema."""
 
 
-    def __init__(self, schema_path='', logging=None, scope=None):
+    def __init__(self, schema_path='', logging=None, scope=None, meta_suffix=None):
         """Create a new SchemaBase object
 
         Parameters
@@ -21,11 +21,15 @@ class SchemaInputBase(Loggable):
             A path to the schema file to input
         scope : string
             An optional 'scope' to apply to all metadata fields
+        meta_suffix : string
+            A suffix to add to each metadata key. Useful when using the same
+            schema for both global and national metadata, for example.
         """
 
         Loggable.__init__(self, logging=logging)
         self.schema_path = schema_path
         self.scope = scope
+        self.meta_suffix = meta_suffix
         self.field_order = []
         self.schema = None
         self.load_schema()
@@ -199,3 +203,21 @@ class SchemaInputBase(Loggable):
             A list of field names in a particular order
         """
         return self.field_order if len(self.field_order) > 0 else self.schema['properties'].keys()
+
+
+    def alter_key(self, key):
+        """Make any changes to a key before adding it to the schema.
+
+        Parameters
+        ----------
+        key : string
+            The key to alter
+
+        Returns
+        -------
+        string
+            The altered key
+        """
+        if self.meta_suffix is not None:
+            key = key + self.meta_suffix
+        return key

--- a/sdg/schemas/SchemaInputOpenSdg.py
+++ b/sdg/schemas/SchemaInputOpenSdg.py
@@ -27,9 +27,10 @@ class SchemaInputOpenSdg(SchemaInputBase):
         # Convert the Prose.io metadata into JSON Schema.
         for field in config['prose']['metadata']['meta']:
             is_required = field['name'] in schema['required']
+            key = self.alter_key(field['name'])
             jsonschema_field = self.prose_field_to_jsonschema(field['field'], is_required)
-            schema['properties'][field['name']] = jsonschema_field
-            self.add_item_to_field_order(field['name'])
+            schema['properties'][key] = jsonschema_field
+            self.add_item_to_field_order(key)
 
         # And similarly, there are certain conditional validation checks.
         schema['allOf'] = [

--- a/sdg/schemas/SchemaInputSdmxMsd.py
+++ b/sdg/schemas/SchemaInputSdmxMsd.py
@@ -18,7 +18,7 @@ class SchemaInputSdmxMsd(SchemaInputBase):
 
         msd = self.parse_xml(self.schema_path)
         for concept in msd.findall('.//Concept'):
-            concept_id = concept.attrib['id']
+            concept_id = self.alter_key(concept.attrib['id'])
             self.add_item_to_field_order(concept_id)
             concept_name = concept.find('./Name').text
             concept_description = concept.find('./Description').text


### PR DESCRIPTION
This allows for the exact same schema to be used for both "global" and "national" for example, but one of these has a suffix added so that their keys are distinct. For example, adding "__GLOBAL" to the end of each of the keys in the global metadata.

A common use-case I expect will be importing global metadata from the UNSD database and importing national metadata from Word files. Without this PR, these would "collide" because they use the same set of metadata keys. But this PR allows one of them to have a suffix, so that they can both coexist in the same metadata set.