### PR TITLE
Vary by language in some method caches

### DIFF
--- a/sdg/Indicator.py
+++ b/sdg/Indicator.py
@@ -35,7 +35,7 @@ class Indicator(Loggable):
         self.set_headline()
         self.set_edges()
         self.translations = {}
-        self.serieses = None
+        self.serieses = {}
         self.data_matching_schema = {}
 
 
@@ -373,8 +373,15 @@ class Indicator(Loggable):
         return self.meta[field]
 
 
-    def get_all_series(self, use_cache=True):
+    def get_all_series(self, use_cache=True, language=None):
         """Get all of the series present in this indicator's data.
+
+        Parameters
+        ----------
+        use_cache : boolean
+            Whether to cache the results of the function.
+        language: string
+            The caching system can consider this optional language.
 
         Returns
         -------
@@ -385,8 +392,10 @@ class Indicator(Loggable):
         if self.data.empty:
             return []
         # Cache for efficiency.
-        if self.serieses is not None and use_cache:
-            return self.serieses
+        if language is None:
+            language = ''
+        if language in self.serieses and use_cache:
+            return self.serieses[language]
 
         # Assume "disaggregations" are everything except 'Year' and 'Value'.
         aggregating_columns = ['Year', 'Value']
@@ -411,19 +420,21 @@ class Indicator(Loggable):
         grouped = grouped.groupby(grouping_columns, as_index=False)[aggregating_columns].agg(lambda x: list(x))
         # Convert to a list of Series objects.
         grouped['series_objects'] = grouped.apply(row_to_series, axis=1)
-        self.serieses = grouped['series_objects'].tolist()
-        return self.serieses
+        self.serieses[language] = grouped['series_objects'].tolist()
+        return self.serieses[language]
 
 
-    def get_data_matching_schema(self, data_schema, data=None, use_cache=True):
+    def get_data_matching_schema(self, data_schema, data=None, use_cache=True, language=None):
         if data is None:
             data = self.data
         # Safety code for empty dataframes.
         if data.empty:
             return data
         # Cache for efficiency.
+        if language is None:
+            language = ''
         schema = data_schema.get_schema_for_indicator(self)
-        cache_key = str(schema.to_dict())
+        cache_key = language + str(schema.to_dict())
         if use_cache and cache_key in self.data_matching_schema:
             return self.data_matching_schema[cache_key]
 

--- a/sdg/outputs/OutputGeoJson.py
+++ b/sdg/outputs/OutputGeoJson.py
@@ -133,7 +133,7 @@ class OutputGeoJson(OutputBase):
             if not self.indicator_has_geocodes(indicator):
                 continue
 
-            series_by_geocodes = self.get_series_by_geocodes(indicator)
+            series_by_geocodes = self.get_series_by_geocodes(indicator, language=language)
             geometry_data = copy.deepcopy(self.geometry_data)
 
             # Loop through the features.
@@ -170,13 +170,15 @@ class OutputGeoJson(OutputBase):
         return status
 
 
-    def get_series_by_geocodes(self, indicator):
+    def get_series_by_geocodes(self, indicator, language=None):
         """Get a dict of lists of Series objects, keyed by geocode ids.
 
         Parameters
         ----------
         indicator : Indicator
             An instance of the Indicator class.
+        language : language
+            A specified language since each language is cached
 
         Returns
         -------
@@ -184,7 +186,7 @@ class OutputGeoJson(OutputBase):
             Lists of instances of the Series class, keyed by geocode id.
         """
         series_by_geocodes = {}
-        for series in indicator.get_all_series():
+        for series in indicator.get_all_series(language=language):
             if series.has_disaggregation(self.id_column):
                 geocode = series.get_disaggregation(self.id_column)
                 geocode = self.replace_geocode(geocode)


### PR DESCRIPTION
This fixes a bug where the GeoJSON output doesn't build correctly in the non-default languages. This bug has the effect in Open SDG of preventing maps from working in non-default languages, so this would be an important fix to get in for 1.4.0, I think.