### PR TITLE
Add TIME_PERIOD to data schema from DSD

### DIFF
--- a/sdg/data_schemas/DataSchemaInputSdmxDsd.py
+++ b/sdg/data_schemas/DataSchemaInputSdmxDsd.py
@@ -21,9 +21,6 @@ class DataSchemaInputSdmxDsd(DataSchemaInputBase):
             dsd = self.source
         schema = {'fields': []}
         for dimension in dsd.dimensions:
-            # Skip the TIME_PERIOD dimension because it is used as the "observation dimension".
-            if dimension.id == 'TIME_PERIOD':
-                continue
             field = {
                 'name': dimension.id,
                 'title': str(dimension.concept_identity.name),


### PR DESCRIPTION
We recently switched from using TIME_DETAIL to TIME_PERIOD, and now the constrain_data option doesn't work in the SDMX output, because TIME_PERIOD is intentionally skipped in the schema, which causes it to think that all rows are invalid. I can't remember the reason that TIME_PERIOD was skipped before. In a quick test this seems to work for me.