### PR TITLE
Allow a dtype parameter in CSV data input

### DIFF
--- a/sdg/inputs/InputCsvData.py
+++ b/sdg/inputs/InputCsvData.py
@@ -6,6 +6,19 @@ from sdg.Indicator import Indicator
 class InputCsvData(InputFiles):
     """Sources of SDG data that are local CSV files."""
 
+    def __init__(self, path_pattern='', logging=None,
+                 column_map=None, code_map=None,
+                 dtype=None):
+        """Constructor for InputCsvData.
+
+        Keyword arguments:
+        dtype: dict showing the datatypes of certain columns.
+        """
+        InputFiles.__init__(self, path_pattern=path_pattern,
+                            logging=logging, column_map=column_map,
+                            code_map=code_map)
+        self.dtype = {} if dtype is None else dtype
+
     def convert_filename_to_indicator_id(self, filename):
         """Assume the file naming convention: 'indicator_1-1-1'."""
         inid = filename.replace('indicator_', '')
@@ -16,5 +29,5 @@ class InputCsvData(InputFiles):
         """Get the data, edges, and headline from CSV, returning a list of indicators."""
         indicator_map = self.get_indicator_map()
         for inid in indicator_map:
-            data = pd.read_csv(indicator_map[inid])
+            data = pd.read_csv(indicator_map[inid], dtype=self.dtype)
             self.add_indicator(inid, data=data, options=indicator_options)


### PR DESCRIPTION
Fixes https://github.com/open-sdg/open-sdg/issues/1271

This allows a dtype parameter to be passed into the InputCsvData class, which is passed along to [read_csv()](https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html).

One reason this might be useful is if a column (like maybe GeoCode) has all numeric values but needs to be treated like a string. For example, if the value `0227` needs to be parsed exactly as `0227` rather than automatically converted to `227.0`, as read_csv normally does for numeric columns.

Usage:

```
  - class: InputCsvData
    path_pattern: data/*.csv
    dtype:
      GeoCode: str
```