### PR TITLE
Make sure disaggregations are sorted as strings

### DIFF
--- a/sdg/outputs/OutputDataPackage.py
+++ b/sdg/outputs/OutputDataPackage.py
@@ -204,7 +204,7 @@ class OutputDataPackage(OutputBase):
             schema.fields.sort(key=lambda field: field.name)
             for field in schema.fields:
                 if 'enum' in field.constraints:
-                    field.constraints['enum'].sort()
+                    field.constraints['enum'].sort(key=str)
 
 
     def translate_data_schema(self, schema, language):


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](add link here)
Fixed issues | Fixes #ISSUENUMBER
Related version | 1.5.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry

I believe this is only a problem in Python 3.8, but is something we should resolve still.

@LucyGwilliamAdmin I believe you can see the issue if you upgrade to Python 3.8 - the UK data has an example of this. Without this change, I believe your build will fail.