### PR TITLE
Reporting status config setting

### DIFF
--- a/sdg/outputs/OutputOpenSdg.py
+++ b/sdg/outputs/OutputOpenSdg.py
@@ -87,12 +87,7 @@ class OutputOpenSdg(OutputBase):
         status = status & sdg.json.write_json('all', all_headline, ftype='headline', site_dir=site_dir)
 
         # Reporting status.
-        reporting_status_types = []
-        if self.schema.get('reporting_status') is not None:
-            status_values = self.schema.get_values('reporting_status')
-            value_translation = self.schema.get_value_translation('reporting_status')
-            reporting_status_types = [{'value': value, 'label': value_translation[value]} for value in status_values]
-        stats_reporting = sdg.stats.reporting_status(reporting_status_types, all_meta, self.reporting_status_grouping_fields)
+        stats_reporting = sdg.stats.reporting_status(all_meta, self.reporting_status_grouping_fields)
         status = status & sdg.json.write_json('reporting', stats_reporting, ftype='stats', site_dir=site_dir)
 
         disaggregation_status_service = sdg.DisaggregationStatusService(site_dir, self.indicators, self.reporting_status_grouping_fields)

--- a/sdg/stats.py
+++ b/sdg/stats.py
@@ -27,6 +27,11 @@ def reporting_status(reporting_status_types, all_meta, extra_fields=None):
         grouping_fields.append('sdg_goal')
 
     # Generate a report of the possible statuses.
+    unique_status_types = {}
+    for indicator_id in all_meta:
+        if 'reporting_status' in all_meta[indicator_id]:
+            unique_status_types[all_meta[indicator_id]['reporting_status']] = True
+    print(unique_status_types)
     status_values = [status['value'] for status in reporting_status_types]
     value_translation = {status['value']: status['label'] for status in reporting_status_types}
     status_report = [{'value': status,

--- a/sdg/stats.py
+++ b/sdg/stats.py
@@ -26,11 +26,12 @@ def reporting_status(all_meta, extra_fields=None):
         grouping_fields.append('sdg_goal')
 
     # Generate a report of the possible statuses.
-    status_values = {}
+    status_values_by_type = {}
     for indicator_id in all_meta:
         if 'reporting_status' in all_meta[indicator_id]:
-            status_values[all_meta[indicator_id]['reporting_status']] = True
-    status_values = status_values.keys()
+            status_values_by_type[all_meta[indicator_id]['reporting_status']] = True
+    status_values = status_values_by_type.keys()
+    print(status_values)
 
     # Omit any standalone indicators.
     indicators = {k: v for (k, v) in all_meta.items() if 'standalone' not in v or v['standalone'] == False }

--- a/sdg/stats.py
+++ b/sdg/stats.py
@@ -30,8 +30,7 @@ def reporting_status(all_meta, extra_fields=None):
     for indicator_id in all_meta:
         if 'reporting_status' in all_meta[indicator_id]:
             status_values_by_type[all_meta[indicator_id]['reporting_status']] = True
-    status_values = status_values_by_type.keys()
-    print(status_values)
+    status_values = list(status_values_by_type.keys())
 
     # Omit any standalone indicators.
     indicators = {k: v for (k, v) in all_meta.items() if 'standalone' not in v or v['standalone'] == False }

--- a/sdg/stats.py
+++ b/sdg/stats.py
@@ -9,10 +9,9 @@ Aggregate information for reporting statistics
 import pandas as pd
 
 
-def reporting_status(reporting_status_types, all_meta, extra_fields=None):
+def reporting_status(all_meta, extra_fields=None):
     """
     Args:
-        reporting_status_types: A list of value/label status types
         all_meta: A dictionary containing all metadata items
         extra_fields: List of fields to group stats by, in addition to goal
 
@@ -27,16 +26,11 @@ def reporting_status(reporting_status_types, all_meta, extra_fields=None):
         grouping_fields.append('sdg_goal')
 
     # Generate a report of the possible statuses.
-    unique_status_types = {}
+    status_values = {}
     for indicator_id in all_meta:
         if 'reporting_status' in all_meta[indicator_id]:
-            unique_status_types[all_meta[indicator_id]['reporting_status']] = True
-    print(unique_status_types)
-    status_values = [status['value'] for status in reporting_status_types]
-    value_translation = {status['value']: status['label'] for status in reporting_status_types}
-    status_report = [{'value': status,
-                      'translation_key': value_translation[status]}
-                    for status in status_values]
+            status_values[all_meta[indicator_id]['reporting_status']] = True
+    status_values = status_values.keys()
 
     # Omit any standalone indicators.
     indicators = {k: v for (k, v) in all_meta.items() if 'standalone' not in v or v['standalone'] == False }
@@ -76,7 +70,6 @@ def reporting_status(reporting_status_types, all_meta, extra_fields=None):
     def one_status_report(g, status):
         count = g.get(status, 0)  # If status is missing use 0
         return {'status': status,
-                'translation_key': value_translation[status],
                 'count': count,
                 'percentage': round(100 * count / g['total'],3)}
 
@@ -91,7 +84,7 @@ def reporting_status(reporting_status_types, all_meta, extra_fields=None):
 
     # Start to build our output.
     output = {
-        'statuses': status_report,
+        'statuses': status_values,
         'overall': total_report,
         'extra_fields': {},
     }

--- a/sdg/stats.py
+++ b/sdg/stats.py
@@ -31,6 +31,7 @@ def reporting_status(all_meta, extra_fields=None):
         if 'reporting_status' in all_meta[indicator_id]:
             status_values_by_type[all_meta[indicator_id]['reporting_status']] = True
     status_values = list(status_values_by_type.keys())
+    status_report = [{'value': status } for status in status_values]
 
     # Omit any standalone indicators.
     indicators = {k: v for (k, v) in all_meta.items() if 'standalone' not in v or v['standalone'] == False }
@@ -84,7 +85,7 @@ def reporting_status(all_meta, extra_fields=None):
 
     # Start to build our output.
     output = {
-        'statuses': status_values,
+        'statuses': status_report,
         'overall': total_report,
         'extra_fields': {},
     }


### PR DESCRIPTION
This PR removes the "translation_key" from the reporting status Open SDG output. This is in support of https://github.com/open-sdg/open-sdg/pull/1350

For backwards compatibility, the "translation_key" should be added in jekyll-open-sdg-plugins. That is done in this PR: https://github.com/open-sdg/jekyll-open-sdg-plugins/pull/112

# Use "Squash and merge" for this!