### PR TITLE
InputSdmxMl_Structure fix: No ID needed on ObsDimension

### DIFF
--- a/sdg/inputs/InputSdmxMl_Structure.py
+++ b/sdg/inputs/InputSdmxMl_Structure.py
@@ -122,7 +122,7 @@ class InputSdmxMl_Structure(InputSdmx):
         observations = self.get_observations(series)
         rows = []
         for observation in observations:
-            year = observation.find(".//ObsDimension[@id='TIME_PERIOD']").attrib['value']
+            year = observation.find(".//ObsDimension").attrib['value']
             obsvalue = observation.find(".//ObsValue")
             if obsvalue is None:
                 continue


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](add link here)
Fixed issues | N/A
Related version | 2.0.0-dev
Bugfix, feature or docs? | Bugfix
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry

The SDMX Converter tool, when it is used to convert data to "GENERIC_DATA_2_1", produces SDMX which is supposed to be compatible with InputSdmxMl_Structure. However the tool does not assign an ID to the ObsDimension elements. But the InputSdmxMl_Structure class expects them to have an ID of "TIME_PERIOD". This PR removes that expectation, allowing the class to find those ObsDimension elements regardless of their ID.