### PR TITLE
Faster git clone for InputSdgMetadata class

### DIFF
--- a/sdg/inputs/InputSdgMetadata.py
+++ b/sdg/inputs/InputSdgMetadata.py
@@ -92,11 +92,11 @@ class InputSdgMetadata(InputBase):
             The name of a Git tag to use (overrides "branch")
         """
 
-        repo = Repo.clone_from(repo_url, folder)
-        if branch:
-            repo.git.checkout(branch)
-        if tag:
-            repo.git.checkout(tag)
+        git_parameters = ['--depth 1']
+        if branch or tag:
+            ref = branch if branch else tag
+            git_parameters.append('--branch ' + ref)
+        Repo.clone_from(repo_url, folder, multi_options=git_parameters)
 
 
     def parse_yaml(self, folder):

--- a/sdg/translations/TranslationInputBase.py
+++ b/sdg/translations/TranslationInputBase.py
@@ -94,11 +94,11 @@ class TranslationInputBase(Loggable):
             The name of a Git tag to use (overrides "branch")
         """
 
-        repo = Repo.clone_from(repo_url, folder)
-        if branch:
-            repo.git.checkout(branch)
-        if tag:
-            repo.git.checkout(tag)
+        git_parameters = ['--depth 1']
+        if branch or tag:
+            ref = branch if branch else tag
+            git_parameters.append('--branch ' + ref)
+        Repo.clone_from(repo_url, folder, multi_options=git_parameters)
 
 
     def execute_once(self):


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](add link here)
Fixed issues | N/A
Related version | 2.0.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry

The InputSdgMetadata class, by default, clones the worldback/sdg-metadata repository, which is very large and takes a long time to clone. The time can be greatly reduced by limiting the clone to a "history" of 1, and cloning only the desired branch/tag.