### PR TITLE
Avoid deprecation warning about squeeze parameter

### DIFF
--- a/sdg/inputs/InputCsvMeta.py
+++ b/sdg/inputs/InputCsvMeta.py
@@ -5,6 +5,6 @@ class InputCsvMeta(InputMetaFiles):
     """Sources of SDG metadata that are local CSV files."""
 
     def read_meta_at_path(self, filepath):
-        meta_df = pd.read_csv(filepath, header=None, index_col=0, squeeze=True)
+        meta_df = pd.read_csv(filepath, header=None, index_col=0).squeeze('columns')
         meta_df = meta_df.dropna()
         return meta_df.to_dict()

--- a/sdg/inputs/InputExcelMeta.py
+++ b/sdg/inputs/InputExcelMeta.py
@@ -23,6 +23,6 @@ class InputExcelMeta(InputMetaFiles):
 
     def read_meta_at_path(self, filepath):
         meta_excel = pd.ExcelFile(filepath)
-        meta_df = meta_excel.parse(meta_excel.sheet_names[self.sheet_number], header=None, index_col=0, squeeze=True)
+        meta_df = meta_excel.parse(meta_excel.sheet_names[self.sheet_number], header=None, index_col=0).squeeze('columns')
         meta_df = meta_df.dropna()
         return meta_df.to_dict()


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](add link here)
Fixed issues | N/A
Related version | 2.0.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry

This avoids a deprecation warning about the squeeze parameter. See "squeeze" here: https://pandas.pydata.org/docs/reference/api/pandas.read_excel.html