### PR TITLE
Skip link for output documentation

### DIFF
--- a/sdg/OutputDocumentationService.py
+++ b/sdg/OutputDocumentationService.py
@@ -424,12 +424,13 @@ class OutputDocumentationService(Loggable):
             </style>
         </head>
         <body>
+            <a class="sr-only-focusable" id="skiplink" href="#main-content" tabindex="0">Skip to main content</a>
             <nav class="navbar navbar-expand-lg navbar-light bg-light">
                 <div class="container">
                     <a class="navbar-brand" href="{baseurl}index.html">{branding}</a>
                 </div>
             </nav>
-            <main role="main">
+            <main id="main-content" role="main">
                 <div class="container">
                     <h1 style="margin:20px 0">{title}</h1>
                     <div>

--- a/sdg/OutputDocumentationService.py
+++ b/sdg/OutputDocumentationService.py
@@ -421,6 +421,31 @@ class OutputDocumentationService(Loggable):
                 .table-striped tbody tr:nth-of-type(2n+1) {{
                     background-color: #f3f2f1;
                 }}
+                #skiplink {{
+                    position: absolute;
+                    top: 0;
+                    left: 50%;
+                    z-index: 10000;
+                    width: 250px;
+                    margin-left: -125px;
+                    padding: 10px;
+                    background: white;
+                    text-align: center;
+                    border: 1px solid #0b0c0c;
+                    color: #0b0c0c;
+                    display: block;
+                }}
+                .sr-only-focusable:not(:focus):not(:focus-within) {{
+                    position: absolute !important;
+                    width: 1px !important;
+                    height: 1px !important;
+                    padding: 0 !important;
+                    margin: -1px !important;
+                    overflow: hidden !important;
+                    clip: rect(0, 0, 0, 0) !important;
+                    white-space: nowrap !important;
+                    border: 0 !important;
+                }}
             </style>
         </head>
         <body>


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-data-docs-skip-link-data/index.html)
Fixed issues | Fixes https://github.com/open-sdg/open-sdg/issues/1754
Related version | 2.1.0-dev
Bugfix, feature or docs? | Feature
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry
