### PR TITLE
Include class name in context for alterations

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,16 @@ Sometimes you may need to alter data and/or metadata before importing into this 
 
 In these callback functions, the thing to be altered is passed as the first parameter, followed by an optional "context" dict, containing other information. These "context" dicts currently contain:
 
-* indicator_id : string
+* indicator_id : string - The id of the indicator, if known
+* class : string - The name of the particular input class that is being altered
 
 For example:
 
 ```
 def my_data_alteration(df, context):
+    # Target a particular input class.
+    if context['class'] != 'InputCsvData':
+      return df
     # Drop an unnecessary column in the data.
     df = df.drop('unnecessary_column', axis='columns')
     # Drop an unnecessary column for one particular indicator.
@@ -56,6 +60,9 @@ def my_data_alteration(df, context):
       df = df.drop('another_column', axis='columns')
     return df
 def my_meta_alteration(meta, context):
+    # Target a particular input class.
+    if context['class'] != 'InputYamlMeta':
+      return df
     # Drop an unecessary field in the metadata.
     del meta['unnecessary_field']
     # Set a metadata field for one particular indicator.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ def my_data_alteration(df, context):
 def my_meta_alteration(meta, context):
     # Target a particular input class.
     if context['class'] != 'InputYamlMeta':
-      return df
+      return meta
     # Drop an unecessary field in the metadata.
     del meta['unnecessary_field']
     # Set a metadata field for one particular indicator.

--- a/sdg/inputs/InputBase.py
+++ b/sdg/inputs/InputBase.py
@@ -229,6 +229,7 @@ class InputBase(Loggable):
             try:
                 data = alteration(data, {
                     'indicator_id': indicator_id,
+                    'class': type(self).__name__,
                 })
             except:
                 # Handle callbacks without the context parameter.
@@ -260,6 +261,7 @@ class InputBase(Loggable):
             try:
                 meta = alteration(meta, {
                     'indicator_id': indicator_id,
+                    'class': type(self).__name__,
                 })
             except:
                 # Handle callbacks without the context parameter.


### PR DESCRIPTION
Data and metadata alterations are applied to particular inputs, but in Open SDG there are often many inputs. For example there might be a CSV data input, an SDMX metadata input, a YAML indicator configuration input, etc. By including the class name of the input in the context object, we can give people a more robust way to target a particular input.