### PR TITLE
Halt build and provide better error messages on YAML syntax problems

### DIFF
--- a/sdg/helpers/files.py
+++ b/sdg/helpers/files.py
@@ -23,3 +23,11 @@ def read_file(location, request_params=None):
         data = file.read()
     file.close()
     return data
+
+
+def print_yaml_syntax_help(file):
+    print('-----')
+    print('The file at ' + file + ' could not be parsed because of a syntax error.')
+    print('YAML syntax errors often involve single/double quotes and/or colons (:).')
+    print('Sometimes you can find the problem by looking at the lines/columns mentioned in the following raw error message:')
+    print('------')

--- a/sdg/helpers/files.py
+++ b/sdg/helpers/files.py
@@ -25,9 +25,9 @@ def read_file(location, request_params=None):
     return data
 
 
-def print_yaml_syntax_help(file):
-    print('-----')
-    print(f'The file at {file} could not be parsed because of a syntax error.')
-    print('YAML syntax errors often involve single/double quotes and/or colons (:).')
-    print('Sometimes you can find the problem by looking at the lines/columns mentioned in the following raw error message:')
-    print('------')
+def get_yaml_syntax_help(file):
+    return f"""-----
+    The file {file} could not be parsed because of a syntax error.
+    YAML syntax errors often involve single/double quotes and/or colon (:).
+    Sometimes you can find the problem by looking at the lines/columns mentioned above.
+    -----"""

--- a/sdg/helpers/files.py
+++ b/sdg/helpers/files.py
@@ -26,7 +26,8 @@ def read_file(location, request_params=None):
 
 
 def get_yaml_syntax_help(file):
-    return f"""-----
+    return f"""
+    -----
     The file {file} could not be parsed because of a syntax error.
     YAML syntax errors often involve single/double quotes and/or colon (:).
     Sometimes you can find the problem by looking at the lines/columns mentioned above.

--- a/sdg/helpers/files.py
+++ b/sdg/helpers/files.py
@@ -30,5 +30,5 @@ def get_yaml_syntax_help(file):
     -----
     The file {file} could not be parsed because of a syntax error.
     YAML syntax errors often involve single/double quotes and/or colon (:).
-    Sometimes you can find the problem by looking at the lines/columns mentioned above.
+    Sometimes you can find the problem by looking at the lines/columns mentioned above by "yaml.parser.ParserError".
     -----"""

--- a/sdg/helpers/files.py
+++ b/sdg/helpers/files.py
@@ -27,7 +27,7 @@ def read_file(location, request_params=None):
 
 def print_yaml_syntax_help(file):
     print('-----')
-    print('The file at ' + file + ' could not be parsed because of a syntax error.')
+    print(f'The file at {file} could not be parsed because of a syntax error.')
     print('YAML syntax errors often involve single/double quotes and/or colons (:).')
     print('Sometimes you can find the problem by looking at the lines/columns mentioned in the following raw error message:')
     print('------')

--- a/sdg/inputs/InputYamlMdMeta.py
+++ b/sdg/inputs/InputYamlMdMeta.py
@@ -13,11 +13,10 @@ class InputYamlMdMeta(InputMetaFiles):
             meta = dict(meta_md[0])
             meta['page_content'] = ''.join(meta_md[1])
         except ParserError as e:
+            print('-----')
             print('The file at ' + filepath + ' could not be parsed because of a syntax error.')
             print('Syntax errors often involve single/double quotes and/or colons (:).')
             print('Sometimes you can find the problem by looking at the lines/columns mentioned in the following raw error message:')
-            print('------')
-            print(e)
             print('------')
             raise
         return meta

--- a/sdg/inputs/InputYamlMdMeta.py
+++ b/sdg/inputs/InputYamlMdMeta.py
@@ -1,7 +1,7 @@
 from sdg.inputs import InputMetaFiles
+from sdg.helpers.files import print_yaml_syntax_help
 from ruamel.yaml.parser import ParserError
 import yamlmd
-import sys
 
 class InputYamlMdMeta(InputMetaFiles):
     """Sources of SDG metadata that are local .md files containing Yaml."""
@@ -13,10 +13,6 @@ class InputYamlMdMeta(InputMetaFiles):
             meta = dict(meta_md[0])
             meta['page_content'] = ''.join(meta_md[1])
         except ParserError as e:
-            print('-----')
-            print('The file at ' + filepath + ' could not be parsed because of a syntax error.')
-            print('Syntax errors often involve single/double quotes and/or colons (:).')
-            print('Sometimes you can find the problem by looking at the lines/columns mentioned in the following raw error message:')
-            print('------')
+            print_yaml_syntax_help(filepath)
             raise
         return meta

--- a/sdg/inputs/InputYamlMdMeta.py
+++ b/sdg/inputs/InputYamlMdMeta.py
@@ -13,6 +13,5 @@ class InputYamlMdMeta(InputMetaFiles):
             meta = dict(meta_md[0])
             meta['page_content'] = ''.join(meta_md[1])
         except ParserError as e:
-            e.add_note(get_yaml_syntax_help(filepath))
-            raise
+            raise Exception(get_yaml_syntax_help(filepath)) from e
         return meta

--- a/sdg/inputs/InputYamlMdMeta.py
+++ b/sdg/inputs/InputYamlMdMeta.py
@@ -19,5 +19,5 @@ class InputYamlMdMeta(InputMetaFiles):
             print('------')
             print(e)
             print('------')
-            sys.exit(1)
+            raise
         return meta

--- a/sdg/inputs/InputYamlMdMeta.py
+++ b/sdg/inputs/InputYamlMdMeta.py
@@ -1,11 +1,23 @@
 from sdg.inputs import InputMetaFiles
+from ruamel.yaml.parser import ParserError
 import yamlmd
+import sys
 
 class InputYamlMdMeta(InputMetaFiles):
     """Sources of SDG metadata that are local .md files containing Yaml."""
 
     def read_meta_at_path(self, filepath):
-        meta_md = yamlmd.read_yamlmd(filepath)
-        meta = dict(meta_md[0])
-        meta['page_content'] = ''.join(meta_md[1])
+        meta = {}
+        try:
+            meta_md = yamlmd.read_yamlmd(filepath)
+            meta = dict(meta_md[0])
+            meta['page_content'] = ''.join(meta_md[1])
+        except ParserError as e:
+            print('The file at ' + filepath + ' could not be parsed because of a syntax error.')
+            print('Syntax errors often involve single/double quotes and/or colons (:).')
+            print('Sometimes you can find the problem by looking at the lines/columns mentioned in the following raw error message:')
+            print('------')
+            print(e)
+            print('------')
+            sys.exit(1)
         return meta

--- a/sdg/inputs/InputYamlMdMeta.py
+++ b/sdg/inputs/InputYamlMdMeta.py
@@ -1,5 +1,5 @@
 from sdg.inputs import InputMetaFiles
-from sdg.helpers.files import print_yaml_syntax_help
+from sdg.helpers.files import get_yaml_syntax_help
 from ruamel.yaml.parser import ParserError
 import yamlmd
 
@@ -13,6 +13,6 @@ class InputYamlMdMeta(InputMetaFiles):
             meta = dict(meta_md[0])
             meta['page_content'] = ''.join(meta_md[1])
         except ParserError as e:
-            print_yaml_syntax_help(filepath)
+            e.add_note(get_yaml_syntax_help(filepath))
             raise
         return meta

--- a/sdg/inputs/InputYamlMeta.py
+++ b/sdg/inputs/InputYamlMeta.py
@@ -1,5 +1,6 @@
 from sdg.inputs import InputMetaFiles
 import yaml
+import sys
 
 
 class InputYamlMeta(InputMetaFiles):
@@ -9,7 +10,16 @@ class InputYamlMeta(InputMetaFiles):
 
         meta = {}
 
-        with open(filepath, 'r', encoding='utf-8') as stream:
-            meta = yaml.load(stream, Loader=yaml.FullLoader)
+        try:
+            with open(filepath, 'r', encoding='utf-8') as stream:
+                meta = yaml.load(stream, Loader=yaml.FullLoader)
+        except yaml.parser.ParserError as e:
+            print('The file at ' + filepath + ' could not be parsed because of a syntax error.')
+            print('Syntax errors often involve single/double quotes and/or colons (:).')
+            print('Sometimes you can find the problem by looking at the lines/columns mentioned in the following raw error message:')
+            print('------')
+            print(e)
+            print('------')
+            sys.exit(1)
 
         return meta

--- a/sdg/inputs/InputYamlMeta.py
+++ b/sdg/inputs/InputYamlMeta.py
@@ -14,11 +14,10 @@ class InputYamlMeta(InputMetaFiles):
             with open(filepath, 'r', encoding='utf-8') as stream:
                 meta = yaml.load(stream, Loader=yaml.FullLoader)
         except yaml.parser.ParserError as e:
+            print('------')
             print('The file at ' + filepath + ' could not be parsed because of a syntax error.')
             print('Syntax errors often involve single/double quotes and/or colons (:).')
             print('Sometimes you can find the problem by looking at the lines/columns mentioned in the following raw error message:')
-            print('------')
-            print(e)
             print('------')
             raise
         return meta

--- a/sdg/inputs/InputYamlMeta.py
+++ b/sdg/inputs/InputYamlMeta.py
@@ -1,5 +1,5 @@
 from sdg.inputs import InputMetaFiles
-from sdg.helpers.files import print_yaml_syntax_help
+from sdg.helpers.files import get_yaml_syntax_help
 import yaml
 
 class InputYamlMeta(InputMetaFiles):
@@ -13,6 +13,6 @@ class InputYamlMeta(InputMetaFiles):
             with open(filepath, 'r', encoding='utf-8') as stream:
                 meta = yaml.load(stream, Loader=yaml.FullLoader)
         except yaml.parser.ParserError as e:
-            print_yaml_syntax_help(filepath)
+            e.add_note(get_yaml_syntax_help(filepath))
             raise
         return meta

--- a/sdg/inputs/InputYamlMeta.py
+++ b/sdg/inputs/InputYamlMeta.py
@@ -20,6 +20,5 @@ class InputYamlMeta(InputMetaFiles):
             print('------')
             print(e)
             print('------')
-            sys.exit(1)
-
+            raise
         return meta

--- a/sdg/inputs/InputYamlMeta.py
+++ b/sdg/inputs/InputYamlMeta.py
@@ -13,6 +13,5 @@ class InputYamlMeta(InputMetaFiles):
             with open(filepath, 'r', encoding='utf-8') as stream:
                 meta = yaml.load(stream, Loader=yaml.FullLoader)
         except yaml.parser.ParserError as e:
-            e.add_note(get_yaml_syntax_help(filepath))
-            raise
+            raise Exception(get_yaml_syntax_help(filepath)) from e
         return meta

--- a/sdg/inputs/InputYamlMeta.py
+++ b/sdg/inputs/InputYamlMeta.py
@@ -1,7 +1,6 @@
 from sdg.inputs import InputMetaFiles
+from sdg.helpers.files import print_yaml_syntax_help
 import yaml
-import sys
-
 
 class InputYamlMeta(InputMetaFiles):
     """Sources of SDG metadata that are local YAML files."""
@@ -14,10 +13,6 @@ class InputYamlMeta(InputMetaFiles):
             with open(filepath, 'r', encoding='utf-8') as stream:
                 meta = yaml.load(stream, Loader=yaml.FullLoader)
         except yaml.parser.ParserError as e:
-            print('------')
-            print('The file at ' + filepath + ' could not be parsed because of a syntax error.')
-            print('Syntax errors often involve single/double quotes and/or colons (:).')
-            print('Sometimes you can find the problem by looking at the lines/columns mentioned in the following raw error message:')
-            print('------')
+            print_yaml_syntax_help(filepath)
             raise
         return meta

--- a/sdg/translations/TranslationInputYaml.py
+++ b/sdg/translations/TranslationInputYaml.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import yaml
 from sdg.translations import TranslationInputBase
-from sdg.helpers.files import print_yaml_syntax_help
+from sdg.helpers.files import get_yaml_syntax_help
 
 class TranslationInputYaml(TranslationInputBase):
     """This class imports translations from local YAML files.
@@ -64,7 +64,7 @@ class TranslationInputYaml(TranslationInputBase):
                                 value = yamldata[key]
                                 self.add_translation(language, group, key, value)
                     except yaml.parser.ParserError as exc:
-                        print_yaml_syntax_help(filepath)
+                        exc.add_note(get_yaml_syntax_help(filepath))
                         raise
 
 

--- a/sdg/translations/TranslationInputYaml.py
+++ b/sdg/translations/TranslationInputYaml.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import yaml
 from sdg.translations import TranslationInputBase
+from sdg.helpers.files import print_yaml_syntax_help
 
 class TranslationInputYaml(TranslationInputBase):
     """This class imports translations from local YAML files.
@@ -53,7 +54,8 @@ class TranslationInputYaml(TranslationInputBase):
                 extension = file_parts[1]
                 if extension != '.yml':
                     continue
-                with open(os.path.join(root, file), 'r', encoding='utf-8') as stream:
+                filepath = os.path.join(root, file)
+                with open(filepath, 'r', encoding='utf-8') as stream:
                     try:
                         yamldata = yaml.load(stream, Loader=yaml.FullLoader)
                         # Loop through the YAML data to add the translations.
@@ -61,8 +63,9 @@ class TranslationInputYaml(TranslationInputBase):
                             for key in yamldata:
                                 value = yamldata[key]
                                 self.add_translation(language, group, key, value)
-                    except Exception as exc:
-                        print(exc)
+                    except yaml.parser.ParserError as exc:
+                        print_yaml_syntax_help(filepath)
+                        raise
 
 
     def execute(self):

--- a/sdg/translations/TranslationInputYaml.py
+++ b/sdg/translations/TranslationInputYaml.py
@@ -64,8 +64,7 @@ class TranslationInputYaml(TranslationInputBase):
                                 value = yamldata[key]
                                 self.add_translation(language, group, key, value)
                     except yaml.parser.ParserError as exc:
-                        exc.add_note(get_yaml_syntax_help(filepath))
-                        raise
+                        raise Exception(get_yaml_syntax_help(filepath)) from exc
 
 
     def execute(self):

--- a/tests/InputYamlMdMeta_test.py
+++ b/tests/InputYamlMdMeta_test.py
@@ -1,6 +1,7 @@
 import sdg
 import os
 import inputs_common
+import pytest
 
 def test_yaml_md_meta_input():
 
@@ -13,3 +14,13 @@ def test_yaml_md_meta_input():
     meta_input.execute(indicator_options=indicator_options)
 
     inputs_common.assert_input_has_correct_meta(meta_input.indicators['1-1-1'].meta)
+
+def test_yaml_md_meta_input_with_problems():
+    meta_pattern = os.path.join('tests', 'assets', 'meta', 'yamlmd-with-problems', '*.md')
+    meta_input = sdg.inputs.InputYamlMdMeta(
+        path_pattern=meta_pattern,
+        git=False,
+    )
+    indicator_options = sdg.IndicatorOptions()
+    with pytest.raises(Exception) as e_info:
+        meta_input.execute(indicator_options=indicator_options)

--- a/tests/InputYamlMeta_test.py
+++ b/tests/InputYamlMeta_test.py
@@ -1,6 +1,7 @@
 import sdg
 import os
 import inputs_common
+import pytest
 
 def test_yaml_meta_input():
 
@@ -13,3 +14,13 @@ def test_yaml_meta_input():
     meta_input.execute(indicator_options=indicator_options)
 
     inputs_common.assert_input_has_correct_meta(meta_input.indicators['1-1-1'].meta)
+
+def test_yaml_meta_input_with_problems():
+    meta_pattern = os.path.join('tests', 'assets', 'meta', 'yaml-with-problems', '*.yml')
+    meta_input = sdg.inputs.InputYamlMeta(
+        path_pattern=meta_pattern,
+        git=False,
+    )
+    indicator_options = sdg.IndicatorOptions()
+    with pytest.raises(Exception) as e_info:
+        meta_input.execute(indicator_options=indicator_options)

--- a/tests/TranslationInputYaml_test.py
+++ b/tests/TranslationInputYaml_test.py
@@ -1,10 +1,19 @@
 import sdg
 import os
+import pytest
 
-def test_translation_input_csv():
+def test_translation_input_yaml():
 
     input = sdg.translations.TranslationInputYaml(
         source=os.path.join('tests', 'assets', 'translations', 'yaml'),
     )
     input.execute()
     assert input.translations['en']['foo']['foo'] == 'bar'
+
+def test_translation_input_yaml_with_problems():
+
+    input = sdg.translations.TranslationInputYaml(
+        source=os.path.join('tests', 'assets', 'translations', 'yaml-with-problems'),
+    )
+    with pytest.raises(Exception) as e_info:
+        input.execute()

--- a/tests/assets/meta/yaml-with-problems/1-1-1.yml
+++ b/tests/assets/meta/yaml-with-problems/1-1-1.yml
@@ -1,0 +1,2 @@
+foo: 'bar 'baz' yarp'
+page_content: Hello world

--- a/tests/assets/meta/yamlmd-with-problems/1-1-1.md
+++ b/tests/assets/meta/yamlmd-with-problems/1-1-1.md
@@ -1,0 +1,4 @@
+---
+foo: 'bar 'baz' yarp'
+---
+Hello world

--- a/tests/assets/translations/yaml-with-problems/en/foo.yml
+++ b/tests/assets/translations/yaml-with-problems/en/foo.yml
@@ -1,0 +1,1 @@
+foo: 'hello 'open' sdg'


### PR DESCRIPTION
Fixes https://github.com/open-sdg/open-sdg/issues/1766

Testing instructions:

This PR includes the following changes:

1. YAML syntax problems in metadata files and indicator configuration files will receive a more helpful error message.
2. YAML syntax problems in translation files will receive a more helpful error message, **and will now prevent the build from continuing**.

I bolded part of the second item above because it is kind of a "breaking change" in that it may prevent builds from completing where previously the completed. However it could be argued that this breaking change is OK, because previously it was failing silently to import the translation files, which probably is causing confusion. So now it will fail, but will remove confusion.

Here is an example of the syntax problem this PR should now catch:

```
foo: 'hello 'open' sdg'
```

To test this, you can try adding the line above in any/all of:

1. YAML indicator metadata files
2. YAML indicator configuration files
3. YAML translation files