### PR TITLE
Avoid key error when report field does not exist in indicator metadata

### DIFF
--- a/sdg/MetadataReportService.py
+++ b/sdg/MetadataReportService.py
@@ -238,7 +238,10 @@ class MetadataReportService(Loggable):
             for field in self.metadata_fields:
                 key = field['key']
                 label = field['label']
-                row[label] = self.get_metadata_field_value_link(store[key]['values'][store[key]['indicators'][indicator]]) if indicator in store[key]['indicators'] else ''
+                if key in store and indicator in store[key]['indicators']:
+                    row[label] = self.get_metadata_field_value_link(store[key]['values'][store[key]['indicators'][indicator]])
+                else:
+                    row[label] = ''
             rows.append(row)
 
         df = pd.DataFrame(rows, columns=['Indicator'] + columns)

--- a/sdg/outputs/OutputSdmxMl.py
+++ b/sdg/outputs/OutputSdmxMl.py
@@ -574,7 +574,7 @@ class OutputSdmxMl(OutputBase):
             "has one per indicator plus an 'all' file. Translations of "
             "the metadata are included in each file using the 'lang' "
             "attribute. The data for this output uses the following "
-            "data structure definition: " + self.dsd_path
+            "data structure definition: " + str(self.dsd_path)
         )
         return description
 

--- a/tests/OutputOpenSdg_test.py
+++ b/tests/OutputOpenSdg_test.py
@@ -71,6 +71,8 @@ def test_open_sdg_output():
         metadata_fields=[{'key': 'foo', 'label': 'Foo'}],
     )
     documentation_service.generate_documentation()
+
+def test_open_sdg_output_documentation():
     documentation_files = [
         'disaggregation-value--m.html',
         'disaggregation--sex.html',

--- a/tests/OutputOpenSdg_test.py
+++ b/tests/OutputOpenSdg_test.py
@@ -20,10 +20,15 @@ def test_open_sdg_output():
     data_input = sdg.inputs.InputCsvData(path_pattern=data_pattern)
     data_input.add_data_alteration(alter_data)
     data_input.add_meta_alteration(alter_meta)
+    meta_pattern = os.path.join('tests', 'assets', 'meta', 'yaml', '*.yml')
+    meta_input = sdg.inputs.InputYamlMeta(
+        path_pattern=meta_pattern,
+        git=False,
+    )
     schema_path = os.path.join('tests', 'assets', 'open-sdg', 'metadata_schema.yml')
     schema = sdg.schemas.SchemaInputOpenSdg(schema_path=schema_path)
     translations = sdg.translations.TranslationInputSdgTranslations()
-    data_output = sdg.outputs.OutputOpenSdg([data_input], schema,
+    data_output = sdg.outputs.OutputOpenSdg([data_input, meta_input], schema,
         translations=[translations],
         output_folder='_site_open_sdg',
     )
@@ -68,7 +73,10 @@ def test_open_sdg_output():
     ]
     documentation_service = sdg.OutputDocumentationService(all_outputs,
         folder='_site_open_sdg',
-        metadata_fields=[{'key': 'foo', 'label': 'Foo'}],
+        metadata_fields=[
+            {'key': 'foo', 'label': 'Foo'},
+            {'key': 'nonexistent', 'label': 'Non-existent'},
+        ],
     )
     documentation_service.generate_documentation()
 

--- a/tests/OutputOpenSdg_test.py
+++ b/tests/OutputOpenSdg_test.py
@@ -56,8 +56,51 @@ def test_open_sdg_output():
 
     exp_dirs = set(['comb', 'data', 'edges', 'csvw', 'data-packages', 'geojson', 'headline', 'meta', 'stats', 'zip', 'translations'])
     act_dirs = os.listdir(english_build)
-    print(act_dirs)
     assert all([a in exp_dirs for a in act_dirs])
+
+    all_outputs = [
+        data_output,
+        csvw_output,
+        datapackage_output,
+        geojson_output,
+        sdmx_output,
+        sdmx_global_output,
+    ]
+    documentation_service = sdg.OutputDocumentationService(all_outputs,
+        folder='_site_open_sdg',
+        metadata_fields=[{'key': 'foo', 'label': 'Foo'}],
+    )
+    documentation_service.generate_documentation()
+    documentation_files = [
+        'disaggregation-value--m.html',
+        'disaggregation--sex.html',
+        'disaggregations.html',
+        'disaggregation-value--f.csv',
+        'disaggregation--geocode.html',
+        'geojson-output-regions.html',
+        'disaggregation-report.csv',
+        'values--disaggregation--geocode.csv',
+        'data-packages.html',
+        'disaggregation-value--f.html',
+        'open-sdg-output.html',
+        'disaggregation-by-indicator-report.csv',
+        'sdmx-output.html',
+        'indicators--disaggregation--geocode.csv',
+        'indicators--disaggregation--sex.csv',
+        'disaggregation-value--e12000001.csv',
+        'sdmx-output_.html',
+        'values--disaggregation--sex.csv',
+        'disaggregation-value--e12000001.html',
+        'disaggregation-value--m.csv',
+        'metadata_field-report.csv',
+        'metadata_field-by-indicator-report.csv',
+        'metadata.html',
+        'index.html',
+        'csvw.html',
+    ]
+    for documentation_file in documentation_files:
+        file_path = os.path.join('_site_open_sdg', documentation_file)
+        assert os.path.exists(file_path)
 
 def test_open_sdg_output_comb():
 

--- a/tests/assets/open-sdg/config_data.yml
+++ b/tests/assets/open-sdg/config_data.yml
@@ -39,3 +39,5 @@ sdmx_output_global:
 docs_metadata_fields:
   - key: foo
     label: Foo
+  - key: nonexistent
+    label: Non-existent

--- a/tests/assets/open-sdg/config_data.yml
+++ b/tests/assets/open-sdg/config_data.yml
@@ -36,3 +36,6 @@ sdmx_output:
   output_subfolder: sdmx
 sdmx_output_global:
   output_subfolder: sdmx-global
+docs_metadata_fields:
+  - key: foo
+    label: Foo

--- a/tests/open_sdg_test.py
+++ b/tests/open_sdg_test.py
@@ -32,3 +32,4 @@ def test_open_sdg():
     OutputOpenSdg_test.test_open_sdg_output_stats_reporting()
     OutputOpenSdg_test.test_open_sdg_output_translations()
     OutputOpenSdg_test.test_open_sdg_output_zip()
+    OutputOpenSdg_test.test_open_sdg_output_documentation()


### PR DESCRIPTION
Testing instructions:

This avoids an error that happens when the metadata report is used with a field that does not have any metadata. For example, the following data config:

```
docs_metadata_fields:
    - key: foo
      label: Foo
```

That would cause a build error, assuming no indicators actually have "foo" metadata. But with this PR, the build would succeed and the metadata report would have a "Foo" column that is blank.
