### PR TITLE
Fall back to source language for missing values in subfolder translations

### DIFF
--- a/sdg/inputs/InputMetaFiles.py
+++ b/sdg/inputs/InputMetaFiles.py
@@ -73,7 +73,12 @@ class InputMetaFiles(InputFiles):
                         if (not meta[language][field]) and (field in meta):
                             # Fallback to source language for missing values.
                             meta[language][field] = meta[field]
-                    
+        # Remove any recursively nested languages within languages
+        for language in languages:
+            if language in meta:
+                for nested_language in languages:
+                    if nested_language in meta[language]:
+                        del meta[language][nested_language]
 
 
     def fix_booleans(self, meta):

--- a/sdg/inputs/InputMetaFiles.py
+++ b/sdg/inputs/InputMetaFiles.py
@@ -70,7 +70,7 @@ class InputMetaFiles(InputFiles):
                 meta[language] = translated_meta
                 if meta[language]:
                     for field in meta[language]:
-                        if !meta[language][field] and field in meta:
+                        if (not meta[language][field]) and (field in meta):
                             # Fallback to source language for missing values.
                             meta[language][field] = meta[field]
                     

--- a/sdg/inputs/InputMetaFiles.py
+++ b/sdg/inputs/InputMetaFiles.py
@@ -68,6 +68,12 @@ class InputMetaFiles(InputFiles):
                 self.apply_metadata_mapping(translated_meta)
                 self.fix_booleans(translated_meta)
                 meta[language] = translated_meta
+                if meta[language]:
+                    for field in meta[language]:
+                        if !meta[language][field] and field in meta:
+                            # Fallback to source language for missing values.
+                            meta[language][field] = meta[field]
+                    
 
 
     def fix_booleans(self, meta):

--- a/sdg/inputs/InputMetaFiles.py
+++ b/sdg/inputs/InputMetaFiles.py
@@ -73,12 +73,6 @@ class InputMetaFiles(InputFiles):
                         if (not meta[language][field]) and (field in meta):
                             # Fallback to source language for missing values.
                             meta[language][field] = meta[field]
-        # Remove any recursively nested languages within languages
-        for language in languages:
-            if language in meta:
-                for nested_language in languages:
-                    if nested_language in meta[language]:
-                        del meta[language][nested_language]
 
 
     def fix_booleans(self, meta):


### PR DESCRIPTION
This is designed to allow the use of subfolder translation for indicator configuration in Open SDG.
