### PR TITLE
Progress measure bugfixes

### DIFF
--- a/sdg/ProgressMeasure.py
+++ b/sdg/ProgressMeasure.py
@@ -157,7 +157,7 @@ class SeriesProgress(IndicatorProgress):
             self.status = get_progress_status(self.progress_value, self.progress_thresholds, self.target_achieved)
             self.score = self.get_score()
 
-    def get_series_tag(self):
+    def get_series_tag(self, sep=' / '):
         """Return a string that identifies the series for which progress is intended to be calculated.
         """
         tag = [self.inid]
@@ -168,7 +168,20 @@ class SeriesProgress(IndicatorProgress):
         if self.disaggregation is not None:
             for disagg in self.disaggregation:
                 tag.append(str(disagg['value']))
-        return ' / '.join(tag)
+        
+        # Limit the tag to <= 122 characters (pyYAML key length limit)
+        # Count the number of characters in the tag (including separators)
+        nchars = [len(chars) for chars in tag]
+        nchars_total = sum(nchars) + len(sep)*(len(tag) - 1)
+        while nchars_total > 122:
+            # Find and truncate the element with the most characters
+            most_chars = max(nchars)
+            i = nchars.index(most_chars)
+            tag[i] = tag[i][:-4] + '...'
+            nchars = [len(chars) for chars in tag]
+            nchars_total = sum(nchars) + len(sep)*(len(tag) - 1)
+
+        return sep.join(tag)
     
     def filter_column(self, data, column, value):
         """Filter the input dataframe, keeping only rows where the value in 'column' is equal to 'value'.

--- a/sdg/ProgressMeasure.py
+++ b/sdg/ProgressMeasure.py
@@ -167,19 +167,27 @@ class SeriesProgress(IndicatorProgress):
             tag.append(self.unit)
         if self.disaggregation is not None:
             for disagg in self.disaggregation:
-                tag.append(disagg['value'])
+                tag.append(str(disagg['value']))
         return ' / '.join(tag)
     
-    def filter_column(self, data, column, field):
-        """Filter the input dataframe, keeping only rows where the value in 'column' is equal to 'field'.
+    def filter_column(self, data, column, value):
+        """Filter the input dataframe, keeping only rows where the value in 'column' is equal to 'value'.
+        If the column is not found in the data, raise an exception.
+        If the value is not found in the data, return the filtered (empty) dataframe and output a warning message.
         """
-        if column in data.columns:
-            if any(data[column] == field):
-                data = data.loc[data[column] == field]
-            else:
-                self.warn(f'{self.inid} - Field {field} not found in column {column} for progress calculation of series: {self.tag}')
+
+        if column not in data.columns:
+            raise Exception(f'{self.inid} - Column {column} not found in data for progress calculation of series: {self.tag}')
+
+        if value is None:
+            if not any(data[column].isna()):
+                self.warn(f'{self.inid} - Value {value} not found column {column} for progress calculation of series: {self.tag}')
+            data = data[data[column].isna()]
         else:
-            self.warn(f'{self.inid} - Column {column} not found in data for progress calculation of series: {self.tag}')
+            if not any(data[column] == value):
+                self.warn(f'{self.inid} - Value {value} not found column {column} for progress calculation of series: {self.tag}')
+            data = data.loc[data[column] == value]
+        
         return data
     
     def filter_data(self):
@@ -216,12 +224,12 @@ class SeriesProgress(IndicatorProgress):
             if self.disaggregation:
                 for disagg in self.disaggregation:
                     data = self.filter_column(data, disagg['field'], disagg['value'])
-            # Otherwise, find headline data (rows where values in all disaggregation dimensions are NA)
-            else:
-                headline = data[data.loc[:, ~data.columns.isin(self.non_disaggregation_columns)].isna().all('columns')]
-                if (len(headline) == 0) and (len(headline) < len(data)):
-                    raise Exception(f'{self.inid} - No headline found for progress calculation of series: {self.tag}')
-                data = headline
+                
+            # Find headline data if multiple disaggregations remain
+            # Get list of columns that have already been filtered + non-disaggregation columns
+            used_columns = self.non_disaggregation_columns + [disagg['field'] for disagg in (self.disaggregation or [])]
+            # Keep only the headline (where the values in all remaining "unused" columns are NA)
+            data = data[data.loc[:, ~data.columns.isin(used_columns)].isna().all('columns')]
             
             # Check if data was sufficiently reduced to a single series/unit/disaggregation
             grouping_columns = [col for col in data.columns if col not in ['Year', 'Value']]


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | n/a
Fixed issues | n/a
Related version | 2.4.0-dev
Bugfix, feature or docs? | Bugfix
* [x] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry

This PR fixes a few minor bugs I ran in to during my final tests.

1. Fix issue where the progress calculation was using the wrong data when a disaggregation was specified in progress_calculation_options but the `value` was not found in the data. The filter step was previously outputting a warning but continuing to pass the unfiltered dataframe. Now, it will pass the filtered (empty) dataframe, which will result in a not_available status, and the user will receive a warning.
2. Better headline selection when disaggregations are specified in the progress_calculation_options. After all specified disaggregations have been filtered for the progress measure, an attempt will be made to select a headline series from the remaining unspecified disaggregation columns. The headline series for the progress measure will include rows where the values in all remaining unspecified disaggregation columns are NA.
3. Fix issue with writing long series tags to indicator_calculation_components.yml. Tags are now truncated to <= 122 characters to fit within pyYAML's max length limit for simple keys.
