### PR TITLE
PX Web - support for multi-value tags

### DIFF
--- a/sdg/helpers/px.py
+++ b/sdg/helpers/px.py
@@ -22,10 +22,13 @@ class Px:
         if k not in self.keywords():
             raise ValueError(f"'{k}' is not a valid KEYWORD")
  
-        if 'TABLE' in self.metadata[k]:
-            return self.metadata[k]['TABLE']
-        else:
+        metadata_keys = self.metadata[k].keys()
+        if 'TABLE' not in metadata_keys:
             return self.metadata[k]
+        elif 'TABLE' in metadata_keys and len(metadata_keys) > 1:
+            return self.metadata[k]
+        else:
+            return self.metadata[k]['TABLE']
 
 
     def title(self):

--- a/sdg/helpers/px.py
+++ b/sdg/helpers/px.py
@@ -21,7 +21,7 @@ class Px:
             k = k + '[' + lang + ']'
         if k not in self.keywords():
             raise ValueError(f"'{k}' is not a valid KEYWORD")
- 
+
         metadata_keys = self.metadata[k].keys()
         if 'TABLE' not in metadata_keys:
             return self.metadata[k]

--- a/sdg/helpers/px.py
+++ b/sdg/helpers/px.py
@@ -21,7 +21,7 @@ class Px:
             k = k + '[' + lang + ']'
         if k not in self.keywords():
             raise ValueError(f"'{k}' is not a valid KEYWORD")
-
+ 
         metadata_keys = self.metadata[k].keys()
         if 'TABLE' not in metadata_keys:
             return self.metadata[k]

--- a/sdg/helpers/px.py
+++ b/sdg/helpers/px.py
@@ -280,7 +280,7 @@ class Px:
         px_metadata = re.sub(r';\s*(\r\n?|\n)', ';;', px_metadata)
         px_metadata = re.sub(r';;$', ';', px_metadata)
         px_metadata = re.sub(r'(\r\n?|\n)', '', px_metadata)
-        px_metadata = re.sub(r'""', ' ', px_metadata)
+        px_metadata = re.sub(r'""', '', px_metadata)
         px_metadata = px_metadata.split(';;')
 
         px_data = px_split[1]

--- a/sdg/helpers/px.py
+++ b/sdg/helpers/px.py
@@ -328,7 +328,10 @@ class Px:
 
 
     def get_units_column_name(self):
-        return self.keyword('UNITS')
+        col = self.keyword('UNITS')
+        if isinstance(col, dict) and 'TABLE' in col:
+            return col['TABLE']
+        return col
 
 
     def get_value_column_name(self):

--- a/sdg/inputs/InputMetaFiles.py
+++ b/sdg/inputs/InputMetaFiles.py
@@ -67,6 +67,7 @@ class InputMetaFiles(InputFiles):
                 translated_meta = self.read_meta_at_path(translated_filepath)
                 self.apply_metadata_mapping(translated_meta)
                 self.fix_booleans(translated_meta)
+                self.remove_empty_values(translated_meta)
                 meta[language] = translated_meta
 
 
@@ -139,3 +140,9 @@ class InputMetaFiles(InputFiles):
             if human_key in metadata and human_key != machine_key:
                 metadata[machine_key] = metadata[human_key]
                 del metadata[human_key]
+
+
+    def remove_empty_values(self, meta):
+        empty_keys = [k for k,v in meta.items() if not v]
+        for k in empty_keys:
+            del meta[k]

--- a/sdg/inputs/InputPxFile.py
+++ b/sdg/inputs/InputPxFile.py
@@ -142,16 +142,16 @@ class InputPxFile(InputBase):
 
 
     def get_meta_map(self, source):
-        if source is None:
-            return {}
-        elif isinstance(source, dict):
-            return source
-        elif isinstance(source, str):
+        map = {}
+        if isinstance(source, str):
             with open(source) as file:
-                return yaml.load(file, Loader=yaml.FullLoader)
+                map = yaml.load(file, Loader=yaml.FullLoader)
+        if isinstance(map, dict):
+            # Always include NOTE mappeed to itself.
+            map['NOTE'] = 'NOTE'
+            return map
         else:
             raise Exception("The meta_map parameter is not configured correctly.")
-        return {}
 
 
     def get_indicator_id_map(self, source):

--- a/sdg/inputs/InputPxFile.py
+++ b/sdg/inputs/InputPxFile.py
@@ -89,17 +89,27 @@ class InputPxFile(InputBase):
                 metadata = {}
                 if not (px.data_has_units() and 'UNITS' in keywords):
                     metadata['computation_units'] = translation_group + '.computation_units'
-                if 'NOTE' in keywords:
-                    note_value = px.keyword('NOTE')
-                    if isinstance(note_value, str):
-                        metadata['data_footnote'] = translation_group + '.data_footnote'
+                if 'NOTEX' in keywords:
+                    notex_value = px.keyword('NOTEX')
+                    if isinstance(notex_value, str):
+                        #metadata['data_footnote'] = translation_group + '.data_footnote'
                         metadata['page_content'] = translation_group + '.page_content'
                 if 'INFO' in keywords:
                     metadata['graph_title'] = translation_group + '.graph_title'
                     metadata['indicator_name'] = translation_group + '.indicator_name'
                 for mapped_key in self.meta_map:
                     if mapped_key in keywords:
-                        metadata[self.meta_map[mapped_key]] = translation_group + '.' + mapped_key
+                        mapped_value = px.keyword(mapped_key)
+                        converted_key = self.meta_map[mapped_key]
+                        if isinstance(mapped_value, str):
+                            metadata[converted_key] = translation_group + '.' + mapped_key
+                        elif isinstance(mapped_value, dict):
+                            value_keys = mapped_value.keys()
+                            for value_key in value_keys:
+                                if value_key == 'TABLE':
+                                    metadata[converted_key] = translation_group + '.' + mapped_key
+                                else:
+                                    metadata[converted_key + '-' + value_key] = translation_group + '.' + mapped_key + '-' + value_key
                 # As a benefit to the Open SGD integration, if the data
                 # is empty, automatically flag it as a non-statistical
                 # indicator.

--- a/sdg/inputs/InputPxFile.py
+++ b/sdg/inputs/InputPxFile.py
@@ -91,9 +91,28 @@ class InputPxFile(InputBase):
                     metadata['computation_units'] = translation_group + '.computation_units'
                 if 'NOTEX' in keywords:
                     notex_value = px.keyword('NOTEX')
+                    notex_header = ''
+                    notex_footer = []
                     if isinstance(notex_value, str):
-                        #metadata['data_footnote'] = translation_group + '.data_footnote'
-                        metadata['page_content'] = translation_group + '.page_content'
+                        notex_header = translation_group + '.page_content'
+                    elif isinstance(notex_value, dict):
+                        value_keys = notex_value.keys()
+                        for value_key in value_keys:
+                            if value_key == 'TABLE':
+                                notex_header = translation_group + '.page_content'
+                            else:
+                                notex_footer.append(value_key)
+                    if notex_header: 
+                        metadata['page_content'] = notex_header
+                    if notex_footer:
+                        if 'footer_fields' not in metadata:
+                            metadata['footer_fields'] = []
+                        for notex_field in notex_footer:
+                            footer_field = {
+                                "label": translation_group + '.footer_field_label-' + notex_field,
+                                "value": translation_group + '.footer_field_value-' + notex_field
+                            }
+                            metadata['footer_fields'].append(footer_field)
                 if 'INFO' in keywords:
                     metadata['graph_title'] = translation_group + '.graph_title'
                     metadata['indicator_name'] = translation_group + '.indicator_name'

--- a/sdg/translations/TranslationInputPx.py
+++ b/sdg/translations/TranslationInputPx.py
@@ -111,8 +111,16 @@ class TranslationInputPx(TranslationInputBase):
                     except:
                         pass
                     for mapped_key in self.meta_map:
+                        metadata_value = ''
                         try:
                             metadata_value = px.keyword(mapped_key, language)
+                        except Exception as e:
+                            # Fallback to untranslated value.
+                            try:
+                                metadata_value = px.keyword(mapped_key)
+                            except Exception as e2:
+                                print(e2)
+                        if metadata_value != '':
                             if isinstance(metadata_value, str):
                                 self.add_translation(language, translation_group, mapped_key, metadata_value)
                             elif isinstance(metadata_value, dict):
@@ -126,9 +134,7 @@ class TranslationInputPx(TranslationInputBase):
                                         untranslated_variable = value_key
                                         translated_variable = px.variable_get_translation_from_value(untranslated_variable, language)
                                         self.add_translation(language, translation_group, mapped_key + '-' + value_key, metadata_value[translated_variable])
-                        except Exception as e:
-                            print(e)
-                            pass
+
 
     def get_meta_map(self, source):
         map = {}

--- a/sdg/translations/TranslationInputPx.py
+++ b/sdg/translations/TranslationInputPx.py
@@ -80,10 +80,28 @@ class TranslationInputPx(TranslationInputBase):
                     except:
                         pass
                     try:
-                        metadata_value = px.keyword('NOTEX', language)
-                        if isinstance(metadata_value, str):
-                            #self.add_translation(language, translation_group, 'data_footnote', metadata_value)
-                            self.add_translation(language, translation_group, 'page_content', metadata_value)
+                        if 'NOTEX' in px.keywords():
+                            metadata_value = px.keyword('NOTEX', language)
+                            notex_header = ''
+                            notex_footer = []
+                            if isinstance(metadata_value, str):
+                                notex_header = metadata_value
+                            elif isinstance(metadata_value, dict):
+                                untranslated_value = px.keyword('NOTEX')
+                                value_keys = untranslated_value.keys()
+                                for value_key in value_keys:
+                                    if value_key == 'TABLE':
+                                        notex_header = metadata_value['TABLE']
+                                    else:
+                                        notex_footer.append(value_key)
+                            if notex_header: 
+                                self.add_translation(language, translation_group, 'page_content', notex_header)
+                            if notex_footer:
+                                for notex_field in notex_footer:
+                                    untranslated_variable = notex_field
+                                    translated_variable = px.variable_get_translation_from_value(untranslated_variable, language)
+                                    self.add_translation(language, translation_group, 'footer_field_label-' + untranslated_variable, translated_variable)
+                                    self.add_translation(language, translation_group, 'footer_field_value-' + untranslated_variable, metadata_value[translated_variable])
                     except:
                         pass
                     try:

--- a/sdg/translations/TranslationInputPx.py
+++ b/sdg/translations/TranslationInputPx.py
@@ -57,9 +57,6 @@ class TranslationInputPx(TranslationInputBase):
                 if has_indicator_options and has_units and translatable_variable == px.get_units_column_name():
                     renamed_variable = self.indicator_options.get_unit_column()
                 for language in languages:
-                    suffix = ''
-                    if language != default_language:
-                        suffix = '[' + language + ']'
                     translated_variable = px.variable_get_translation_from_value(translatable_variable, language)
                     self.add_translation(language, renamed_variable, renamed_variable, translated_variable)
                     codes = px.codes(translatable_variable)
@@ -131,16 +128,17 @@ class TranslationInputPx(TranslationInputBase):
                             pass
 
     def get_meta_map(self, source):
-        if source is None:
-            return {}
-        elif isinstance(source, dict):
-            return source
-        elif isinstance(source, str):
+        map = {}
+        if isinstance(source, str):
             with open(source) as file:
-                return yaml.load(file, Loader=yaml.FullLoader)
+                map = yaml.load(file, Loader=yaml.FullLoader)
+        if isinstance(map, dict):
+            # Always include NOTE mappeed to itself.
+            map['NOTE'] = 'NOTE'
+            return map
         else:
             raise Exception("The meta_map parameter is not configured correctly.")
-        return {}
+
 
     def get_indicator_id_map(self, source):
         if isinstance(source, dict):

--- a/sdg/translations/TranslationInputPx.py
+++ b/sdg/translations/TranslationInputPx.py
@@ -80,9 +80,9 @@ class TranslationInputPx(TranslationInputBase):
                     except:
                         pass
                     try:
-                        metadata_value = px.keyword('NOTE', language)
+                        metadata_value = px.keyword('NOTEX', language)
                         if isinstance(metadata_value, str):
-                            self.add_translation(language, translation_group, 'data_footnote', metadata_value)
+                            #self.add_translation(language, translation_group, 'data_footnote', metadata_value)
                             self.add_translation(language, translation_group, 'page_content', metadata_value)
                     except:
                         pass
@@ -95,8 +95,21 @@ class TranslationInputPx(TranslationInputBase):
                     for mapped_key in self.meta_map:
                         try:
                             metadata_value = px.keyword(mapped_key, language)
-                            self.add_translation(language, translation_group, mapped_key, metadata_value)
-                        except:
+                            if isinstance(metadata_value, str):
+                                self.add_translation(language, translation_group, mapped_key, metadata_value)
+                            elif isinstance(metadata_value, dict):
+                                untranslated_value = px.keyword(mapped_key)
+                                value_keys = untranslated_value.keys()
+                                for value_key in value_keys:
+                                    if value_key == 'TABLE':
+                                        self.add_translation(language, translation_group, mapped_key, metadata_value['TABLE'])
+                                    else:
+                                        # We assume this is a variable.
+                                        untranslated_variable = value_key
+                                        translated_variable = px.variable_get_translation_from_value(untranslated_variable, language)
+                                        self.add_translation(language, translation_group, mapped_key + '-' + value_key, metadata_value[translated_variable])
+                        except Exception as e:
+                            print(e)
                             pass
 
     def get_meta_map(self, source):

--- a/sdg/translations/TranslationInputPx.py
+++ b/sdg/translations/TranslationInputPx.py
@@ -73,7 +73,10 @@ class TranslationInputPx(TranslationInputBase):
                     try:
                         if not (px.data_has_units() and 'UNITS' in px.keywords()):
                             metadata_value = px.keyword('UNITS', language)
-                            self.add_translation(language, translation_group, 'computation_units', metadata_value)
+                            if isinstance(metadata_value, dict) and 'TABLE' in metadata_value:
+                                metadata_value = metadata_value['TABLE']
+                            if isinstance(metadata_value, str):
+                                self.add_translation(language, translation_group, 'computation_units', metadata_value)
                     except:
                         pass
                     try:

--- a/sdg/translations/TranslationInputPx.py
+++ b/sdg/translations/TranslationInputPx.py
@@ -111,16 +111,8 @@ class TranslationInputPx(TranslationInputBase):
                     except:
                         pass
                     for mapped_key in self.meta_map:
-                        metadata_value = ''
                         try:
                             metadata_value = px.keyword(mapped_key, language)
-                        except Exception as e:
-                            # Fallback to untranslated value.
-                            try:
-                                metadata_value = px.keyword(mapped_key)
-                            except Exception as e2:
-                                print(e2)
-                        if metadata_value != '':
                             if isinstance(metadata_value, str):
                                 self.add_translation(language, translation_group, mapped_key, metadata_value)
                             elif isinstance(metadata_value, dict):
@@ -134,7 +126,9 @@ class TranslationInputPx(TranslationInputBase):
                                         untranslated_variable = value_key
                                         translated_variable = px.variable_get_translation_from_value(untranslated_variable, language)
                                         self.add_translation(language, translation_group, mapped_key + '-' + value_key, metadata_value[translated_variable])
-
+                        except Exception as e:
+                            print(e)
+                            pass
 
     def get_meta_map(self, source):
         map = {}

--- a/tests/InputPxFile_test.py
+++ b/tests/InputPxFile_test.py
@@ -510,26 +510,17 @@ def test_px_input():
     """
 
     correct_meta_english = {
+        'NOTE': 'Testing note',
         'computation_units': 'Testing units',
-        'data_footnote': 'Testing note',
-        'page_content': 'Testing note',
         'graph_title': 'Testing info',
         'indicator_name': 'Testing info',
-        'CONTACT': 'Testing contact',
-        'META_LAST_UPDATE': '20230911 09:00',
-        'DATA_SOURCE': 'Testing source',
     }
     correct_meta_faroese = {
+        'NOTE': 'Testing note FO',
         'computation_units': 'Testing units FO',
-        'data_footnote': 'Testing note FO',
-        'page_content': 'Testing note FO',
         'graph_title': 'Testing info FO',
         'indicator_name': 'Testing info FO',
-        'CONTACT': 'Testing contact FO',
-        'META_LAST_UPDATE': '20230911 09:00',
-        'DATA_SOURCE': 'Testing source FO',
     }
-    print(indicator.language('fo').meta)
     inputs_common.assert_input_has_correct_data(indicator.language('en').data, correct_data_english)
     inputs_common.assert_input_has_correct_data(indicator.language('fo').data, correct_data_faroese)
     inputs_common.assert_input_has_correct_meta(indicator.language('en').meta, correct_meta_english)


### PR DESCRIPTION
This adds support for NOTE and NOTEX, both single-value and multi-value. The rules are as follows:

NOTEX single-value: Appears at the top of the indicator page, as "page_content"
NOTEX multi-value: Appears beneath the graph as a footnote
NOTE single-value and multi-value: Appears in metadata

"NOTE" appearing in metadata requires that "NOTE" be added to the metadata schema file. The multi-value versions of "NOTE" also need to be added to the metadata schema file, as "NOTE-[category]". For example, "NOTE-party".